### PR TITLE
updated num_parms for ops and check for max eval=0

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   unit-test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -38,6 +39,7 @@ jobs:
         run: ./build.sh check
 
   agent-test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -70,6 +72,7 @@ jobs:
         run: python3 -m pytest agent-test --capture=no --log-cli-level=debug
 
   integration-test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository

--- a/src/agent/rda.c
+++ b/src/agent/rda.c
@@ -462,7 +462,7 @@ void rda_scan_sbrs_cb(rh_elt_t *elt, void *tag)
         if((RULE_IS_ACTIVE(rule->flags))
            && (TimeCompare(rule->eval_at, ctx->nowtime) <= 0))
         {
-                if(rule->def.as_sbr.max_eval > rule->num_eval)
+                if(rule->def.as_sbr.max_eval > rule->num_eval || rule->def.as_sbr.max_eval == 0)
                 {
                         vec_push(ctx->vec, rule);
                 }

--- a/src/indep_adms/agent/adm_amp_agent_agent.c
+++ b/src/indep_adms/agent/adm_amp_agent_agent.c
@@ -164,7 +164,7 @@ void amp_agent_init_var()
 	expr = expr_create(AMP_TYPE_UINT);
 	expr_add_item(expr, adm_build_ari(AMP_TYPE_EDD, 0, g_amp_agent_idx[ADM_EDD_IDX], AMP_AGENT_EDD_NUM_TBR));
 	expr_add_item(expr, adm_build_ari(AMP_TYPE_EDD, 0, g_amp_agent_idx[ADM_EDD_IDX], AMP_AGENT_EDD_NUM_SBR));
-	expr_add_item(expr, adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT));
+	expr_add_item(expr, adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT));
 	adm_add_var_from_expr(id, AMP_TYPE_UINT, expr);
 }
 

--- a/src/indep_adms/agent/adm_amp_agent_impl.c
+++ b/src/indep_adms/agent/adm_amp_agent_impl.c
@@ -1901,6 +1901,7 @@ tnv_t *amp_agent_ctrl_add_sbr(eid_t *def_mgr, tnvc_t *parms, int8_t *status)
 
 		if(rh_code != RH_OK)
 		{
+			AMP_DEBUG_ERR("ADD_SBR", "Unable to add SBR to DB, %d", rh_code);
 			rule_release(sbr, 1);
 		}
 		else

--- a/src/ion_if/bpv7/adm/adm_bpsec_agent.c
+++ b/src/ion_if/bpv7/adm/adm_bpsec_agent.c
@@ -151,7 +151,7 @@ void dtn_bpsec_init_var()
 	expr = expr_create(AMP_TYPE_UINT);
 	expr_add_item(expr, adm_build_ari(AMP_TYPE_EDD, 0, g_dtn_bpsec_idx[ADM_EDD_IDX], DTN_BPSEC_EDD_NUM_BAD_TX_BIB_BLKS));
 	expr_add_item(expr, adm_build_ari(AMP_TYPE_EDD, 0, g_dtn_bpsec_idx[ADM_EDD_IDX], DTN_BPSEC_EDD_NUM_BAD_TX_BCB_BLKS));
-	expr_add_item(expr, adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT));
+	expr_add_item(expr, adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT));
 	adm_add_var_from_expr(id, AMP_TYPE_UINT, expr);
 }
 

--- a/src/ion_if/bpv7/adm/adm_bpsec_mgr.c
+++ b/src/ion_if/bpv7/adm/adm_bpsec_mgr.c
@@ -362,7 +362,7 @@ void dtn_bpsec_init_var()
 	expr = expr_create(AMP_TYPE_UINT);
 	expr_add_item(expr, adm_build_ari(AMP_TYPE_EDD, 0, g_dtn_bpsec_idx[ADM_EDD_IDX], DTN_BPSEC_EDD_NUM_BAD_TX_BIB_BLKS));
 	expr_add_item(expr, adm_build_ari(AMP_TYPE_EDD, 0, g_dtn_bpsec_idx[ADM_EDD_IDX], DTN_BPSEC_EDD_NUM_BAD_TX_BCB_BLKS));
-	expr_add_item(expr, adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT));
+	expr_add_item(expr, adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT));
 	adm_add_var_from_expr(id, AMP_TYPE_UINT, expr);
 	meta_add_var(AMP_TYPE_UINT, id, ADM_ENUM_DTN_BPSEC, "total_bad_tx_blks", "This is the number of failed TX blocks (# failed BIB + # failed bcb).");
 

--- a/src/ion_if/mgr/adm_amp_agent_mgr.c
+++ b/src/ion_if/mgr/adm_amp_agent_mgr.c
@@ -162,368 +162,368 @@ void amp_agent_init_op()
 	metadata_t *meta = NULL;
 
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_INT, id, ADM_ENUM_AMP_AGENT, "plusINT", "Int32 addition");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_INT);
 	meta_add_parm(meta, "O2", AMP_TYPE_INT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UINT, id, ADM_ENUM_AMP_AGENT, "plusUINT", "Unsigned Int32 addition");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UINT);
 	meta_add_parm(meta, "O2", AMP_TYPE_UINT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_VAST, id, ADM_ENUM_AMP_AGENT, "plusVAST", "Int64 addition");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_VAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_VAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSUVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "plusUVAST", "Unsigned Int64 addition");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSREAL32);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSREAL32);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL32, id, ADM_ENUM_AMP_AGENT, "plusREAL32", "Real32 addition");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL32);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL32);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSREAL64);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_PLUSREAL64);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL64, id, ADM_ENUM_AMP_AGENT, "plusREAL64", "Real64 addition");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL64);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL64);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_INT, id, ADM_ENUM_AMP_AGENT, "minusINT", "Int32 subtraction");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_INT);
 	meta_add_parm(meta, "O2", AMP_TYPE_INT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSUINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSUINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UINT, id, ADM_ENUM_AMP_AGENT, "minusUINT", "Unsigned Int32 subtraction");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UINT);
 	meta_add_parm(meta, "O2", AMP_TYPE_UINT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_VAST, id, ADM_ENUM_AMP_AGENT, "minusVAST", "Int64 subtraction");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_VAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_VAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSUVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSUVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "minusUVAST", "Unsigned Int64 subtraction");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSREAL32);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSREAL32);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL32, id, ADM_ENUM_AMP_AGENT, "minusREAL32", "Real32 subtraction");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL32);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL32);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSREAL64);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MINUSREAL64);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL64, id, ADM_ENUM_AMP_AGENT, "minusREAL64", "Real64 subtraction");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL64);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL64);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_INT, id, ADM_ENUM_AMP_AGENT, "multINT", "Int32 multiplication");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_INT);
 	meta_add_parm(meta, "O2", AMP_TYPE_INT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTUINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTUINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UINT, id, ADM_ENUM_AMP_AGENT, "multUINT", "Unsigned Int32 multiplication");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UINT);
 	meta_add_parm(meta, "O2", AMP_TYPE_UINT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_VAST, id, ADM_ENUM_AMP_AGENT, "multVAST", "Int64 multiplication");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_VAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_VAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTUVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTUVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "multUVAST", "Unsigned Int64 multiplication");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTREAL32);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTREAL32);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL32, id, ADM_ENUM_AMP_AGENT, "multREAL32", "Real32 multiplication");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL32);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL32);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTREAL64);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MULTREAL64);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL64, id, ADM_ENUM_AMP_AGENT, "multREAL64", "Real64 multiplication");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL64);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL64);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_INT, id, ADM_ENUM_AMP_AGENT, "divINT", "Int32 division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_INT);
 	meta_add_parm(meta, "O2", AMP_TYPE_INT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVUINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVUINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UINT, id, ADM_ENUM_AMP_AGENT, "divUINT", "Unsigned Int32 division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UINT);
 	meta_add_parm(meta, "O2", AMP_TYPE_UINT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_VAST, id, ADM_ENUM_AMP_AGENT, "divVAST", "Int64 division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_VAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_VAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVUVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVUVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "divUVAST", "Unsigned Int64 division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVREAL32);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVREAL32);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL32, id, ADM_ENUM_AMP_AGENT, "divREAL32", "Real32 division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL32);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL32);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVREAL64);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_DIVREAL64);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL64, id, ADM_ENUM_AMP_AGENT, "divREAL64", "Real64 division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL64);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL64);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_INT, id, ADM_ENUM_AMP_AGENT, "modINT", "Int32 modulus division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_INT);
 	meta_add_parm(meta, "O2", AMP_TYPE_INT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODUINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODUINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UINT, id, ADM_ENUM_AMP_AGENT, "modUINT", "Unsigned Int32 modulus division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UINT);
 	meta_add_parm(meta, "O2", AMP_TYPE_UINT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_VAST, id, ADM_ENUM_AMP_AGENT, "modVAST", "Int64 modulus division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_VAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_VAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODUVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODUVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "modUVAST", "Unsigned Int64 modulus division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODREAL32);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODREAL32);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL32, id, ADM_ENUM_AMP_AGENT, "modREAL32", "Real32 modulus division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL32);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL32);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODREAL64);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_MODREAL64);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL64, id, ADM_ENUM_AMP_AGENT, "modREAL64", "Real64 modulus division");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL64);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL64);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_INT, id, ADM_ENUM_AMP_AGENT, "expINT", "Int32 exponentiation");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_INT);
 	meta_add_parm(meta, "O2", AMP_TYPE_INT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPUINT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPUINT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UINT, id, ADM_ENUM_AMP_AGENT, "expUINT", "Unsigned int32 exponentiation");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UINT);
 	meta_add_parm(meta, "O2", AMP_TYPE_UINT);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_VAST, id, ADM_ENUM_AMP_AGENT, "expVAST", "Int64 exponentiation");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_VAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_VAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPUVAST);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPUVAST);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "expUVAST", "Unsigned Int64 exponentiation");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPREAL32);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPREAL32);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL32, id, ADM_ENUM_AMP_AGENT, "expREAL32", "Real32 exponentiation");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL32);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL32);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPREAL64);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EXPREAL64);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_REAL64, id, ADM_ENUM_AMP_AGENT, "expREAL64", "Real64 exponentiation");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_REAL64);
 	meta_add_parm(meta, "O2", AMP_TYPE_REAL64);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITAND);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITAND);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "bitAND", "Bitwise and");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITOR);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITOR);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "bitOR", "Bitwise or");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITXOR);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITXOR);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "bitXOR", "Bitwise xor");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITNOT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITNOT);
 	adm_add_op_ari(id, 1, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "bitNOT", "Bitwise not");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LOGAND);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LOGAND);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "logAND", "Logical and");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_BOOL);
 	meta_add_parm(meta, "O2", AMP_TYPE_BOOL);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LOGOR);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LOGOR);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "logOR", "Logical or");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_BOOL);
 	meta_add_parm(meta, "O2", AMP_TYPE_BOOL);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LOGNOT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LOGNOT);
 	adm_add_op_ari(id, 1, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "logNOT", "Logical not");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_BOOL);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_ABS);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_ABS);
 	adm_add_op_ari(id, 1, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "abs", "absolute value");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_VAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LESSTHAN);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LESSTHAN);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "lessThan", "<");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UNK);
 	meta_add_parm(meta, "O2", AMP_TYPE_UNK);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_GREATERTHAN);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_GREATERTHAN);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "greaterThan", ">");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UNK);
 	meta_add_parm(meta, "O2", AMP_TYPE_UNK);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LESSEQUAL);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_LESSEQUAL);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "lessEqual", "<=");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UNK);
 	meta_add_parm(meta, "O2", AMP_TYPE_UNK);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_GREATEREQUAL);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_GREATEREQUAL);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "greaterEqual", ">=");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UNK);
 	meta_add_parm(meta, "O2", AMP_TYPE_UNK);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_NOTEQUAL);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_NOTEQUAL);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "notEqual", "!=");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UNK);
 	meta_add_parm(meta, "O2", AMP_TYPE_UNK);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EQUAL);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_EQUAL);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_BOOL, id, ADM_ENUM_AMP_AGENT, "Equal", "==");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UNK);
 	meta_add_parm(meta, "O2", AMP_TYPE_UNK);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITSHIFTLEFT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITSHIFTLEFT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "bitShiftLeft", "<<");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITSHIFTRIGHT);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_BITSHIFTRIGHT);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UVAST, id, ADM_ENUM_AMP_AGENT, "bitShiftRight", ">>");
 
 	meta_add_parm(meta, "O1", AMP_TYPE_UVAST);
 	meta_add_parm(meta, "O2", AMP_TYPE_UVAST);
 
-	id = adm_build_ari(AMP_TYPE_OPER, 1, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_STOR);
+	id = adm_build_ari(AMP_TYPE_OPER, 0, g_amp_agent_idx[ADM_OPER_IDX], AMP_AGENT_OP_STOR);
 	adm_add_op_ari(id, 2, NULL);
 	meta = meta_add_op(AMP_TYPE_UNK, id, ADM_ENUM_AMP_AGENT, "STOR", "Store value of parm 2 in parm 1");
 

--- a/src/shared/adm/adm.c
+++ b/src/shared/adm/adm.c
@@ -401,7 +401,8 @@ int adm_add_op_ari(ari_t *id, uint8_t num_parm, op_fn apply_fn)
 int adm_add_op(vec_idx_t nn, amp_uvast name, uint8_t num_parm, op_fn apply_fn)
 {
 	// The OPER ARI itself has no parameters, but the operator consumes stack items
-	return adm_add_op_ari(adm_build_ari(AMP_TYPE_OPER, 1, nn, name),num_parm, apply_fn);
+	// the OPER ARI could have parameters but the num_parm is actually num_operands
+	return adm_add_op_ari(adm_build_ari(AMP_TYPE_OPER,  0, nn, name),num_parm, apply_fn);
 }
 
 

--- a/testenv/check.sh
+++ b/testenv/check.sh
@@ -21,9 +21,9 @@ set -e
 SELFDIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 cd "${SELFDIR}"
 
-docker-compose ps
+docker compose ps
 
-DEXEC="docker-compose exec -T nm-mgr"
+DEXEC="docker compose exec -T nm-mgr"
 
 # Wait a few seconds for ION to start
 for IX in $(seq 10)

--- a/testenv/start.sh
+++ b/testenv/start.sh
@@ -23,5 +23,5 @@ cd "${SELFDIR}"
 
 export DOCKER_BUILDKIT=1
 
-docker-compose build
-docker-compose up -d
+docker compose build
+docker compose up -d

--- a/testenv/stop.sh
+++ b/testenv/stop.sh
@@ -21,5 +21,5 @@ set -e
 SELFDIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 cd "${SELFDIR}"
 
-docker-compose stop
-docker-compose rm -fv
+docker compose stop
+docker compose rm -fv


### PR DESCRIPTION
There is an issue where the internal nm ARI builder was setting all the operator has_parm to true even when they dont actually have parameters. ACE was not setting the has_parm flag to true so sending commands with operatings to the nm from anms was not working. Current fix is by setting the num_parm to 0 when creating an operator. Also fixed a check with max_evals for SBR so now 0 means theres no max  