### PR TITLE
ARI handling updates for CBOR in text form

### DIFF
--- a/src/cace/ari/text.h
+++ b/src/cace/ari/text.h
@@ -100,9 +100,6 @@ typedef struct
      * False to use decimal fraction form.
      */
     bool time_text;
-
-    // cbor_diag:bool = False
-
 } ari_text_enc_opts_t;
 
 #define ARI_TEXT_ENC_OPTS_DEFAULT                                                                                     \

--- a/src/cace/ari/text_val.lex
+++ b/src/cace/ari/text_val.lex
@@ -302,10 +302,6 @@ DECDIG [0-9]
     return T_IDENTITY;
 }
 
-<LT_CBOR>\<\<(.*)\>\> {
-    return T_CBOR_DIAG;
-}
-
 <*>\0|\n {
     // ignore trailing null
 }

--- a/src/cace/ari/text_val.yac
+++ b/src/cace/ari/text_val.yac
@@ -65,7 +65,6 @@ void cace_ari_text_val_error(yyscan_t *scanner, const cace_ari_text_val_t *input
 %token <lit> T_IDENTITY
 %token <lit> T_TSTR
 %token <lit> T_BSTR
-%token <lit> T_CBOR_DIAG
 %token <lit> T_TIMEPOINT
 %token <lit> T_TIMEDIFF
 %token <lit> T_DECFRAC
@@ -96,7 +95,6 @@ litval:
     | T_TIMEPOINT
     | T_TIMEDIFF
     | T_DECFRAC
-    | T_CBOR_DIAG
 ;
 
 %%

--- a/test/cace/test_ari_text.c
+++ b/test/cace/test_ari_text.c
@@ -606,6 +606,35 @@ void test_ari_text_decode_lit_prim_bstr(const char *text, const char *expect, si
     ari_deinit(&ari);
 }
 
+TEST_CASE("ari:/CBOR/h''", NULL, 0)
+TEST_CASE("ari:/CBOR/h'A164746573748203F94480'", "\xA1\x64\x74\x65\x73\x74\x82\x03\xF9\x44\x80", 11)
+TEST_CASE("ari:/CBOR/h'A1%2064%2074%2065%2073%2074%2082%2003%20F9%2044%20%2080'", "\xA1\x64\x74\x65\x73\x74\x82\x03\xF9\x44\x80", 11)
+void test_ari_text_decode_lit_typed_cbor(const char *text, const char *expect, size_t expect_len)
+{
+    ari_t ari = ARI_INIT_UNDEFINED;
+    check_decode(&ari, text);
+    TEST_ASSERT_FALSE(ari.is_ref);
+    TEST_ASSERT_EQUAL_INT(ARI_TYPE_CBOR, ari.as_lit.ari_type);
+    TEST_ASSERT_EQUAL_INT(ARI_PRIM_BSTR, ari.as_lit.prim_type);
+
+    if (expect)
+    {
+        cace_data_t expect_data;
+        cace_data_init_view(&expect_data, expect_len, (cace_data_ptr_t)expect);
+        TEST_ASSERT_TRUE(ari.as_lit.value.as_data.owned);
+        TEST_ASSERT_EQUAL_INT(expect_data.len, ari.as_lit.value.as_data.len);
+        TEST_ASSERT_EQUAL_MEMORY(expect_data.ptr, ari.as_lit.value.as_data.ptr, ari.as_lit.value.as_data.len);
+        cace_data_deinit(&expect_data);
+    }
+    else
+    {
+        TEST_ASSERT_FALSE(ari.as_lit.value.as_data.owned);
+        TEST_ASSERT_EQUAL_INT(0, ari.as_lit.value.as_data.len);
+        TEST_ASSERT_NULL(ari.as_lit.value.as_data.ptr);
+    }
+    ari_deinit(&ari);
+}
+
 TEST_CASE("ari:/NULL/null")
 TEST_CASE("ari:/0/null")
 void test_ari_text_decode_lit_typed_null(const char *text)
@@ -816,7 +845,6 @@ TEST_CASE("ari://!test/this/that")     // ODM path
 TEST_CASE("ari://test/this/that(34)")
 TEST_CASE("ari://2/CTRL/4(hi)")
 TEST_CASE("ari:/CBOR/h'0A'")
-//TEST_CASE("ari:/CBOR/%3C%3C10%3E%3E") // memory corruption????
 TEST_CASE("ari:/CBOR/h'A164746573748203F94480'")
 void test_ari_text_loopback(const char *intext)
 {

--- a/test/cace/test_ari_text.c
+++ b/test/cace/test_ari_text.c
@@ -701,25 +701,27 @@ void test_ari_text_decode_lit_prim_bstr(const char *text, const char *expect, si
     ari_deinit(&ari);
 }
 
-TEST_CASE("ari:/CBOR/h''", NULL, 0)
-TEST_CASE("ari:/CBOR/h'A164746573748203F94480'", "\xA1\x64\x74\x65\x73\x74\x82\x03\xF9\x44\x80", 11)
-TEST_CASE("ari:/CBOR/h'A1%2064%2074%2065%2073%2074%2082%2003%20F9%2044%20%2080'", "\xA1\x64\x74\x65\x73\x74\x82\x03\xF9\x44\x80", 11)
-void test_ari_text_decode_lit_typed_cbor(const char *text, const char *expect, size_t expect_len)
+TEST_CASE("ari:/CBOR/h''", "ari:/BYTESTR/h''", 0)
+TEST_CASE("ari:/CBOR/h'A164746573748203F94480'", "ari:/BYTESTR/h'A164746573748203F94480'", 11)
+TEST_CASE("ari:/CBOR/h'0064746573748203F94480'", "ari:/BYTESTR/h'0064746573748203F94480'", 11)
+TEST_CASE("ari:/CBOR/h'A1%2064%2074%2065%2073%2074%2082%2003%20F9%2044%20%2080'", "ari:/CBOR/h'A1%2064%2074%2065%2073%2074%2082%2003%20F9%2044%20%2080'", 11)
+void test_ari_text_decode_lit_typed_cbor(const char *text, const char *expect, int expect_len)
 {
     ari_t ari = ARI_INIT_UNDEFINED;
+    ari_t ari_expect = ARI_INIT_UNDEFINED;
     check_decode(&ari, text);
+    check_decode(&ari_expect, expect);
+
     TEST_ASSERT_FALSE(ari.is_ref);
     TEST_ASSERT_EQUAL_INT(ARI_TYPE_CBOR, ari.as_lit.ari_type);
     TEST_ASSERT_EQUAL_INT(ARI_PRIM_BSTR, ari.as_lit.prim_type);
 
-    if (expect)
+    if (expect_len > 0)
     {
-        cace_data_t expect_data;
-        cace_data_init_view(&expect_data, expect_len, (cace_data_ptr_t)expect);
         TEST_ASSERT_TRUE(ari.as_lit.value.as_data.owned);
-        TEST_ASSERT_EQUAL_INT(expect_data.len, ari.as_lit.value.as_data.len);
-        TEST_ASSERT_EQUAL_MEMORY(expect_data.ptr, ari.as_lit.value.as_data.ptr, ari.as_lit.value.as_data.len);
-        cace_data_deinit(&expect_data);
+        TEST_ASSERT_EQUAL_INT(ari_expect.as_lit.value.as_data.len, ari.as_lit.value.as_data.len);
+        TEST_ASSERT_EQUAL_INT(expect_len, ari.as_lit.value.as_data.len);
+        TEST_ASSERT_EQUAL_MEMORY(ari_expect.as_lit.value.as_data.ptr, ari.as_lit.value.as_data.ptr, ari.as_lit.value.as_data.len);
     }
     else
     {
@@ -728,6 +730,7 @@ void test_ari_text_decode_lit_typed_cbor(const char *text, const char *expect, s
         TEST_ASSERT_NULL(ari.as_lit.value.as_data.ptr);
     }
     ari_deinit(&ari);
+    ari_deinit(&ari_expect);
 }
 
 TEST_CASE("ari:/NULL/null")

--- a/test/cace/test_ari_text.c
+++ b/test/cace/test_ari_text.c
@@ -815,6 +815,9 @@ TEST_CASE("ari://test@1234/this/that") // ADM revision
 TEST_CASE("ari://!test/this/that")     // ODM path
 TEST_CASE("ari://test/this/that(34)")
 TEST_CASE("ari://2/CTRL/4(hi)")
+TEST_CASE("ari:/CBOR/h'0A'")
+//TEST_CASE("ari:/CBOR/%3C%3C10%3E%3E") // memory corruption????
+TEST_CASE("ari:/CBOR/h'A164746573748203F94480'")
 void test_ari_text_loopback(const char *intext)
 {
     ari_t    ari = ARI_INIT_UNDEFINED;


### PR DESCRIPTION
Remove CBOR extended diagnostic notation as it is not practical to add support for parsing EDN.

Add additional unit tests for ARI's containing typed CBOR.