### PR TITLE
ARI handling updates for references in binary form

### DIFF
--- a/src/cace/ari/access.c
+++ b/src/cace/ari/access.c
@@ -385,15 +385,22 @@ struct ari_rptset_s *ari_init_rptset(ari_t *ari)
 
 void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_id, const char *obj_id)
 {
+    ari_set_objref_path_textid_opt(ari, false, ns_id, false, type_id, false, obj_id);
+}
+
+void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, bool has_type, ari_type_t type_id, bool has_obj, const char *obj_id)
+{
     CHKVOID(ari);
     ari_deinit(ari);
 
     ari_ref_t *ref = ari_init_objref(ari);
+    if (has_ns)
     {
         ref->objpath.ns_id.form = ARI_IDSEG_TEXT;
         string_t *value         = &(ref->objpath.ns_id.as_text);
         string_init_set_str(*value, ns_id);
     }
+    if (has_type)
     {
         // FIXME better way to handle this?
         const char *type_name     = ari_type_to_name(type_id);
@@ -401,6 +408,7 @@ void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_i
         string_t *value           = &(ref->objpath.type_id.as_text);
         string_init_set_str(*value, type_name);
     }
+    if (has_obj)
     {
         ref->objpath.obj_id.form = ARI_IDSEG_TEXT;
         string_t *value          = &(ref->objpath.obj_id.as_text);
@@ -413,18 +421,26 @@ void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_i
 
 void ari_set_objref_path_intid(ari_t *ari, int64_t ns_id, ari_type_t type_id, int64_t obj_id)
 {
+    ari_set_objref_path_intid_opt(ari, false, ns_id, false, type_id, false, obj_id);
+}
+
+void ari_set_objref_path_intid_opt(ari_t *ari, bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id)
+{
     CHKVOID(ari);
     ari_deinit(ari);
 
     ari_ref_t *ref = ari_init_objref(ari);
+    if (has_ns)
     {
         ref->objpath.ns_id.form   = ARI_IDSEG_INT;
         ref->objpath.ns_id.as_int = ns_id;
     }
+    if (has_type)
     {
         ref->objpath.type_id.form   = ARI_IDSEG_INT;
         ref->objpath.type_id.as_int = type_id;
     }
+    if (has_obj)
     {
         ref->objpath.obj_id.form   = ARI_IDSEG_INT;
         ref->objpath.obj_id.as_int = obj_id;

--- a/src/cace/ari/access.c
+++ b/src/cace/ari/access.c
@@ -421,7 +421,7 @@ void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, 
 
 void ari_set_objref_path_intid(ari_t *ari, int64_t ns_id, ari_type_t type_id, int64_t obj_id)
 {
-    ari_set_objref_path_intid_opt(ari, false, ns_id, false, type_id, false, obj_id);
+    ari_set_objref_path_intid_opt(ari, true, ns_id, true, type_id, true, obj_id);
 }
 
 void ari_set_objref_path_intid_opt(ari_t *ari, bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id)

--- a/src/cace/ari/access.c
+++ b/src/cace/ari/access.c
@@ -385,33 +385,33 @@ struct ari_rptset_s *ari_init_rptset(ari_t *ari)
 
 void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_id, const char *obj_id)
 {
-    ari_set_objref_path_textid_opt(ari, true, ns_id, true, type_id, true, obj_id);
+    ari_set_objref_path_textid_opt(ari, ns_id, &type_id, obj_id);
 }
 
-void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, bool has_type, ari_type_t type_id, bool has_obj, const char *obj_id)
+void ari_set_objref_path_textid_opt(ari_t *ari, const char *ns_id, const ari_type_t *type_id, const char *obj_id)
 {
     CHKVOID(ari);
     ari_deinit(ari);
 
     ari_ref_t *ref = ari_init_objref(ari);
-    if (has_ns)
+    if (ns_id)
     {
         ref->objpath.ns_id.form = ARI_IDSEG_TEXT;
         string_t *value         = &(ref->objpath.ns_id.as_text);
         string_init_set_str(*value, ns_id);
     }
-    if (has_type)
+    if (type_id)
     {
         // FIXME better way to handle this?
-        const char *type_name     = ari_type_to_name(type_id);
+        const char *type_name     = ari_type_to_name(*type_id);
         ref->objpath.type_id.form = ARI_IDSEG_TEXT;
         string_t *value           = &(ref->objpath.type_id.as_text);
         string_init_set_str(*value, type_name);
 
         ref->objpath.has_ari_type = true;
-        ref->objpath.ari_type     = type_id;
+        ref->objpath.ari_type     = *type_id;
     }
-    if (has_obj)
+    if (obj_id)
     {
         ref->objpath.obj_id.form = ARI_IDSEG_TEXT;
         string_t *value          = &(ref->objpath.obj_id.as_text);
@@ -421,32 +421,32 @@ void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, 
 
 void ari_set_objref_path_intid(ari_t *ari, int64_t ns_id, ari_type_t type_id, int64_t obj_id)
 {
-    ari_set_objref_path_intid_opt(ari, true, ns_id, true, type_id, true, obj_id);
+    ari_set_objref_path_intid_opt(ari, &ns_id, &type_id, &obj_id);
 }
 
-void ari_set_objref_path_intid_opt(ari_t *ari, bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id)
+void ari_set_objref_path_intid_opt(ari_t *ari, const int64_t *ns_id, const ari_type_t *type_id, const int64_t *obj_id)
 {
     CHKVOID(ari);
     ari_deinit(ari);
 
     ari_ref_t *ref = ari_init_objref(ari);
-    if (has_ns)
+    if (ns_id)
     {
         ref->objpath.ns_id.form   = ARI_IDSEG_INT;
-        ref->objpath.ns_id.as_int = ns_id;
+        ref->objpath.ns_id.as_int = *ns_id;
     }
-    if (has_type)
+    if (type_id)
     {
         ref->objpath.type_id.form   = ARI_IDSEG_INT;
-        ref->objpath.type_id.as_int = type_id;
+        ref->objpath.type_id.as_int = *type_id;
 
         ref->objpath.has_ari_type = true;
-        ref->objpath.ari_type     = type_id;
+        ref->objpath.ari_type     = *type_id;
     }
-    if (has_obj)
+    if (obj_id)
     {
         ref->objpath.obj_id.form   = ARI_IDSEG_INT;
-        ref->objpath.obj_id.as_int = obj_id;
+        ref->objpath.obj_id.as_int = *obj_id;
     }
 }
 

--- a/src/cace/ari/access.c
+++ b/src/cace/ari/access.c
@@ -407,6 +407,9 @@ void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, 
         ref->objpath.type_id.form = ARI_IDSEG_TEXT;
         string_t *value           = &(ref->objpath.type_id.as_text);
         string_init_set_str(*value, type_name);
+
+        ref->objpath.has_ari_type = true;
+        ref->objpath.ari_type     = type_id;
     }
     if (has_obj)
     {
@@ -414,9 +417,6 @@ void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, 
         string_t *value          = &(ref->objpath.obj_id.as_text);
         string_init_set_str(*value, obj_id);
     }
-
-    ref->objpath.has_ari_type = true;
-    ref->objpath.ari_type     = type_id;
 }
 
 void ari_set_objref_path_intid(ari_t *ari, int64_t ns_id, ari_type_t type_id, int64_t obj_id)
@@ -439,15 +439,15 @@ void ari_set_objref_path_intid_opt(ari_t *ari, bool has_ns, int64_t ns_id, bool 
     {
         ref->objpath.type_id.form   = ARI_IDSEG_INT;
         ref->objpath.type_id.as_int = type_id;
+
+        ref->objpath.has_ari_type = true;
+        ref->objpath.ari_type     = type_id;
     }
     if (has_obj)
     {
         ref->objpath.obj_id.form   = ARI_IDSEG_INT;
         ref->objpath.obj_id.as_int = obj_id;
     }
-
-    ref->objpath.has_ari_type = true;
-    ref->objpath.ari_type     = type_id;
 }
 
 void ari_set_objref_params_ac(ari_t *ari, struct ari_ac_s *src)

--- a/src/cace/ari/access.c
+++ b/src/cace/ari/access.c
@@ -385,7 +385,7 @@ struct ari_rptset_s *ari_init_rptset(ari_t *ari)
 
 void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_id, const char *obj_id)
 {
-    ari_set_objref_path_textid_opt(ari, false, ns_id, false, type_id, false, obj_id);
+    ari_set_objref_path_textid_opt(ari, true, ns_id, true, type_id, true, obj_id);
 }
 
 void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, bool has_type, ari_type_t type_id, bool has_obj, const char *obj_id)

--- a/src/cace/ari/access.h
+++ b/src/cace/ari/access.h
@@ -136,7 +136,8 @@ void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_i
  *
  * @param[in,out] ari The ARI value to modify.
  * @param[in] ns_id The namespace path segment, or NULL for none.
- * @param type_id The object type path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
+ * @param type_id The object type path segment, or NULL for none. The pointed-to lifetime does not need to outlast this
+ * function call.
  * @param[in] obj_id The object ID path segment, or NULL for none.
  */
 void ari_set_objref_path_textid_opt(ari_t *ari, const char *ns_id, const ari_type_t *type_id, const char *obj_id);
@@ -153,9 +154,12 @@ void ari_set_objref_path_intid(ari_t *ari, int64_t ns_id, ari_type_t type_id, in
 /** Set the ARI as an object reference with a specific integer-enumerated path.
  *
  * @param[in,out] ari The ARI value to modify.
- * @param ns_id The namespace path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
- * @param type_id The object type path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
- * @param obj_id The object ID path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
+ * @param ns_id The namespace path segment, or NULL for none. The pointed-to lifetime does not need to outlast this
+ * function call.
+ * @param type_id The object type path segment, or NULL for none. The pointed-to lifetime does not need to outlast this
+ * function call.
+ * @param obj_id The object ID path segment, or NULL for none. The pointed-to lifetime does not need to outlast this
+ * function call.
  */
 void ari_set_objref_path_intid_opt(ari_t *ari, const int64_t *ns_id, const ari_type_t *type_id, const int64_t *obj_id);
 

--- a/src/cace/ari/access.h
+++ b/src/cace/ari/access.h
@@ -132,6 +132,18 @@ struct ari_rptset_s *ari_init_rptset(ari_t *ari);
  */
 void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_id, const char *obj_id);
 
+/** Set the ARI as an object reference with a specific text-named path.
+ *
+ * @param[in,out] ari The ARI value to modify.
+ * @param[in] has_ns Determine whether namespace path segment is present.
+ * @param[in] ns_id The namespace path segment.
+ * @param[in] has_type Determine whether object type path segment is present.
+ * @param type_id The object type path segment.
+ * @param[in] has_obj Determine whether object ID path segment is present.
+ * @param[in] obj_id The object ID path segment.
+ */
+void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, bool has_type, ari_type_t type_id, bool has_obj, const char *obj_id);
+
 /** Set the ARI as an object reference with a specific integer-enumerated path.
  *
  * @param[in,out] ari The ARI value to modify.
@@ -140,6 +152,18 @@ void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_i
  * @param obj_id The object ID path segment.
  */
 void ari_set_objref_path_intid(ari_t *ari, int64_t ns_id, ari_type_t type_id, int64_t obj_id);
+
+/** Set the ARI as an object reference with a specific integer-enumerated path.
+ *
+ * @param[in,out] ari The ARI value to modify.
+ * @param has_ns Determine whether namespace path segment is present.
+ * @param ns_id The namespace path segment.
+ * @param has_type Determine whether object type path segment is present.
+ * @param type_id The object type path segment.
+ * @param has_obj Determine whether object ID path segment is present.
+ * @param obj_id The object ID path segment.
+ */
+void ari_set_objref_path_intid_opt(ari_t *ari, bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id);
 
 /** Set just the parameters of an object reference ARI.
  *

--- a/src/cace/ari/access.h
+++ b/src/cace/ari/access.h
@@ -135,14 +135,11 @@ void ari_set_objref_path_textid(ari_t *ari, const char *ns_id, ari_type_t type_i
 /** Set the ARI as an object reference with a specific text-named path.
  *
  * @param[in,out] ari The ARI value to modify.
- * @param[in] has_ns Determine whether namespace path segment is present.
- * @param[in] ns_id The namespace path segment.
- * @param[in] has_type Determine whether object type path segment is present.
- * @param type_id The object type path segment.
- * @param[in] has_obj Determine whether object ID path segment is present.
- * @param[in] obj_id The object ID path segment.
+ * @param[in] ns_id The namespace path segment, or NULL for none.
+ * @param type_id The object type path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
+ * @param[in] obj_id The object ID path segment, or NULL for none.
  */
-void ari_set_objref_path_textid_opt(ari_t *ari, bool has_ns, const char *ns_id, bool has_type, ari_type_t type_id, bool has_obj, const char *obj_id);
+void ari_set_objref_path_textid_opt(ari_t *ari, const char *ns_id, const ari_type_t *type_id, const char *obj_id);
 
 /** Set the ARI as an object reference with a specific integer-enumerated path.
  *
@@ -156,14 +153,11 @@ void ari_set_objref_path_intid(ari_t *ari, int64_t ns_id, ari_type_t type_id, in
 /** Set the ARI as an object reference with a specific integer-enumerated path.
  *
  * @param[in,out] ari The ARI value to modify.
- * @param has_ns Determine whether namespace path segment is present.
- * @param ns_id The namespace path segment.
- * @param has_type Determine whether object type path segment is present.
- * @param type_id The object type path segment.
- * @param has_obj Determine whether object ID path segment is present.
- * @param obj_id The object ID path segment.
+ * @param ns_id The namespace path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
+ * @param type_id The object type path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
+ * @param obj_id The object ID path segment, or NULL for none. The pointed-to lifetime does not need to outlast this function call.
  */
-void ari_set_objref_path_intid_opt(ari_t *ari, bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id);
+void ari_set_objref_path_intid_opt(ari_t *ari, const int64_t *ns_id, const ari_type_t *type_id, const int64_t *obj_id);
 
 /** Set just the parameters of an object reference ARI.
  *

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -185,9 +185,6 @@ TEST_CASE(true, 65536, false, 0, false, 0, "831A00010000F6F6") // ari://65536/
 TEST_CASE(true, -20, false, 0, false, 0, "8333F6F6") // ari://-20/
 TEST_CASE(false, 0, true, ARI_TYPE_IDENT, true, 34, "83F6201822") // ./IDENT/34
 TEST_CASE(true, 18, true, ARI_TYPE_IDENT, true, 34, "8312201822") // ari://18/IDENT/34
-// TODO:
-///home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://2/CTRL/4(hi)"):INFO: Encoded hex: 8402220481626869
-///home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://2/CTRL/4(hi)"):PASS
 void test_ari_cbor_encode_objref_path_int(bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -160,19 +160,21 @@ void test_ari_cbor_encode_lit_typed_ac_1item(void)
     }
 }
 
-TEST_CASE("example-adm-a@2024-06-25", false, 0, NULL, "8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6") // ari://example-adm-a@2024-06-25/
-TEST_CASE("example-adm-a", false, 0, NULL, "836D6578616D706C652D61646D2D61F6F6") // ari://example-adm-a/
+TEST_CASE("example-adm-a@2024-06-25", false, 0, NULL,
+          "8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6")             // ari://example-adm-a@2024-06-25/
+TEST_CASE("example-adm-a", false, 0, NULL, "836D6578616D706C652D61646D2D61F6F6")    // ari://example-adm-a/
 TEST_CASE("!example-odm-b", false, 0, NULL, "836E216578616D706C652D6F646D2D62F6F6") // ari://!example-odm-b/
-TEST_CASE("adm", false, 0, NULL, "836361646DF6F6") // ari://adm/
-TEST_CASE(NULL, true, ARI_TYPE_CONST, "hi", "83F621626869") // "./CONST/hi
-TEST_CASE("adm", true, ARI_TYPE_CONST, "hi", "836361646D21626869") // ari://adm/CONST/hi
-TEST_CASE("test", true, ARI_TYPE_CONST, "that", "836474657374216474686174") // ari://test/CONST/that
+TEST_CASE("adm", false, 0, NULL, "836361646DF6F6")                                  // ari://adm/
+TEST_CASE(NULL, true, ARI_TYPE_CONST, "hi", "83F621626869")                         // "./CONST/hi
+TEST_CASE("adm", true, ARI_TYPE_CONST, "hi", "836361646D21626869")                  // ari://adm/CONST/hi
+TEST_CASE("test", true, ARI_TYPE_CONST, "that", "836474657374216474686174")         // ari://test/CONST/that
 TEST_CASE("test@1234", true, ARI_TYPE_CONST, "that", "8369746573744031323334216474686174") // ari://test@1234/CONST/that
-TEST_CASE("!test", true, ARI_TYPE_CONST, "that", "83652174657374216474686174") // ari://!test/CONST/that
-void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari_type_t type_id, const char *obj_id, const char *expect)
+TEST_CASE("!test", true, ARI_TYPE_CONST, "that", "83652174657374216474686174")             // ari://!test/CONST/that
+void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari_type_t type_id, const char *obj_id,
+                                           const char *expect)
 {
-    ari_t ari = ARI_INIT_UNDEFINED;
-    bool has_ns = ns_id != NULL, has_obj = obj_id != NULL;
+    ari_t ari    = ARI_INIT_UNDEFINED;
+    bool  has_ns = ns_id != NULL, has_obj = obj_id != NULL;
     ari_set_objref_path_textid_opt(&ari, has_ns ? ns_id : NULL, has_type ? &type_id : NULL, has_obj ? obj_id : NULL);
 
     check_encoding(&ari, expect);
@@ -180,12 +182,13 @@ void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari
     ari_deinit(&ari);
 }
 
-TEST_CASE(true, 18, false, 0, false, 0, "8312F6F6") // ari://18/
-TEST_CASE(true, 65536, false, 0, false, 0, "831A00010000F6F6") // ari://65536/
-TEST_CASE(true, -20, false, 0, false, 0, "8333F6F6") // ari://-20/
+TEST_CASE(true, 18, false, 0, false, 0, "8312F6F6")               // ari://18/
+TEST_CASE(true, 65536, false, 0, false, 0, "831A00010000F6F6")    // ari://65536/
+TEST_CASE(true, -20, false, 0, false, 0, "8333F6F6")              // ari://-20/
 TEST_CASE(false, 0, true, ARI_TYPE_IDENT, true, 34, "83F6201822") // ./IDENT/34
 TEST_CASE(true, 18, true, ARI_TYPE_IDENT, true, 34, "8312201822") // ari://18/IDENT/34
-void test_ari_cbor_encode_objref_path_int(bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id, const char *expect)
+void test_ari_cbor_encode_objref_path_int(bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj,
+                                          int64_t obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;
     ari_set_objref_path_intid_opt(&ari, has_ns ? &ns_id : NULL, has_type ? &type_id : NULL, has_obj ? &obj_id : NULL);
@@ -218,12 +221,13 @@ static void check_decoding(ari_t *ari, const char *inhex)
     TEST_ASSERT_TRUE_MESSAGE(amm_builtin_validate(ari), "amm_builtin_validate() failed");
 }
 
-TEST_CASE("836361646D21626869", "adm", ARI_TYPE_CONST, "hi") // ari://adm/CONST/hi
-TEST_CASE("836474657374216474686174", "test", ARI_TYPE_CONST, "that") // "ari://test/CONST/that
+TEST_CASE("836361646D21626869", "adm", ARI_TYPE_CONST, "hi")                         // ari://adm/CONST/hi
+TEST_CASE("836474657374216474686174", "test", ARI_TYPE_CONST, "that")                // "ari://test/CONST/that
 TEST_CASE("8369746573744031323334216474686174", "test@1234", ARI_TYPE_CONST, "that") // ari://test@1234/CONST/that
-TEST_CASE("83652174657374216474686174", "!test", ARI_TYPE_CONST, "that") // ari://!test/CONST/that
-TEST_CASE("846474657374226474686174811822", "test", ARI_TYPE_CTRL, "that") // ari://test/CTRL/that(34)
-void test_ari_cbor_decode_objref_path_text(const char *hexval, const char *ns_id, ari_type_t type_id, const char *obj_id)
+TEST_CASE("83652174657374216474686174", "!test", ARI_TYPE_CONST, "that")             // ari://!test/CONST/that
+TEST_CASE("846474657374226474686174811822", "test", ARI_TYPE_CTRL, "that")           // ari://test/CTRL/that(34)
+void test_ari_cbor_decode_objref_path_text(const char *hexval, const char *ns_id, ari_type_t type_id,
+                                           const char *obj_id)
 {
     ari_t ari = ARI_INIT_UNDEFINED;
 

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -160,6 +160,28 @@ void test_ari_cbor_encode_lit_typed_ac_1item(void)
     }
 }
 
+void test_ari_cbor_encode_objref_path_text_with_param(void)
+{
+//TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // ari://test/CTRL/that(34)
+    ari_t ari = ARI_INIT_UNDEFINED;
+    ari_ac_t acinit;
+    ari_set_objref_path_textid_opt(&ari, true, "test", true, ARI_TYPE_CTRL, true, "that");
+    ari_ac_init(&acinit);
+    {
+        ari_t *item = ari_list_push_back_new(acinit.items);
+        ari_set_int(item, 34);
+    }
+
+    ari_set_objref_params_ac(&ari, &acinit);
+
+    check_encoding(&ari, "846474657374226474686174811822");
+
+//846474657374226474686174811822
+//83647465737422687468617428333429
+
+    ari_deinit(&ari);
+}
+
 TEST_CASE("example-adm-a@2024-06-25", false, 0, NULL, "8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6") // ari://example-adm-a@2024-06-25/
 TEST_CASE("example-adm-a", false, 0, NULL, "836D6578616D706C652D61646D2D61F6F6") // ari://example-adm-a/
 TEST_CASE("!example-odm-b", false, 0, NULL, "836E216578616D706C652D6F646D2D62F6F6") // ari://!example-odm-b/
@@ -169,7 +191,7 @@ TEST_CASE("adm", true, ARI_TYPE_CONST, "hi", "836361646D21626869") // ari://adm/
 TEST_CASE("test", true, ARI_TYPE_CONST, "that", "836474657374216474686174") // ari://test/CONST/that
 TEST_CASE("test@1234", true, ARI_TYPE_CONST, "that", "8369746573744031323334216474686174") // ari://test@1234/CONST/that
 TEST_CASE("!test", true, ARI_TYPE_CONST, "that", "83652174657374216474686174") // ari://!test/CONST/that
-// TODO: TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // ari://test/CTRL/that(34)
+TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // ari://test/CTRL/that(34)
 void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari_type_t type_id, const char *obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -173,7 +173,7 @@ void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari
 {
     ari_t ari = ARI_INIT_UNDEFINED;
     bool has_ns = ns_id != NULL, has_obj = obj_id != NULL;
-    ari_set_objref_path_textid_opt(&ari, has_ns, ns_id, has_type, type_id, has_obj, obj_id);
+    ari_set_objref_path_textid_opt(&ari, has_ns ? ns_id : NULL, has_type ? &type_id : NULL, has_obj ? obj_id : NULL);
 
     check_encoding(&ari, expect);
 
@@ -188,7 +188,7 @@ TEST_CASE(true, 18, true, ARI_TYPE_IDENT, true, 34, "8312201822") // ari://18/ID
 void test_ari_cbor_encode_objref_path_int(bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;
-    ari_set_objref_path_intid_opt(&ari, has_ns, ns_id, has_type, type_id, has_obj, obj_id);
+    ari_set_objref_path_intid_opt(&ari, has_ns ? &ns_id : NULL, has_type ? &type_id : NULL, has_obj ? &obj_id : NULL);
 
     check_encoding(&ari, expect);
 

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -160,6 +160,61 @@ void test_ari_cbor_encode_lit_typed_ac_1item(void)
     }
 }
 
+/*
+
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://adm/"):INFO: Encoded hex: 836361646DF6F6
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://adm/"):FAIL: parser error 3
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://example-adm-a@2024-06-25/"):INFO: Encoded hex: 8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://example-adm-a@2024-06-25/"):FAIL: parser error 3
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://example-adm-a/"):INFO: Encoded hex: 836D6578616D706C652D61646D2D61F6F6
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://example-adm-a/"):FAIL: parser error 3
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://!example-odm-b/"):INFO: Encoded hex: 836E216578616D706C652D6F646D2D62F6F6
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://!example-odm-b/"):FAIL: parser error 3
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://65536/"):INFO: Encoded hex: 831A00010000F6F6
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://65536/"):FAIL: parser error 3
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://-20/"):INFO: Encoded hex: 8333F6F6
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://-20/"):FAIL: parser error 3
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://test/CONST/that"):INFO: Encoded hex: 836474657374216474686174
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://test/CONST/that"):PASS
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://test@1234/CONST/that"):INFO: Encoded hex: 8369746573744031323334216474686174
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://test@1234/CONST/that"):PASS
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://!test/CONST/that"):INFO: Encoded hex: 83652174657374216474686174
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://!test/CONST/that"):PASS
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://test/CTRL/that(34)"):INFO: Encoded hex: 846474657374226474686174811822
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://test/CTRL/that(34)"):PASS
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://2/CTRL/4(hi)"):INFO: Encoded hex: 8402220481626869
+/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://2/CTRL/4(hi)"):PASS
+*/
+
+
+TEST_CASE(NULL, ARI_TYPE_CONST, "hi", "83F621626869") // "./CONST/hi"
+TEST_CASE("adm", ARI_TYPE_CONST, "hi", "836361646D21626869") // "ari://adm/CONST/hi"
+void test_ari_cbor_encode_objref_path_text(const char *ns_id, ari_type_t type_id, const char *obj_id, const char *expect)
+{
+    ari_t ari = ARI_INIT_UNDEFINED;
+    bool has_ns = ns_id != NULL, has_type = true, has_obj = obj_id != NULL;
+    ari_set_objref_path_textid_opt(&ari, has_ns, ns_id, has_type, type_id, has_obj, obj_id);
+
+    check_encoding(&ari, expect);
+
+    ari_deinit(&ari);
+}
+
+//TEST_CASE(true, 18, false, 0, false, 0, "8312F6F6") // "ari://18/"
+//TEST_CASE(true, 65536, false, 0, false, 0, "831A00010000F6F6") // "ari://65536/"
+// TODO: TEST_CASE(true, -20, false, 0, false, 0, "8333F6F6") // "ari://-20/"
+TEST_CASE(false, 0, true, ARI_TYPE_IDENT, true, 34, "83F6201822") // "./IDENT/34"
+TEST_CASE(true, 18, true, ARI_TYPE_IDENT, true, 34, "8312201822") // "ari://18/IDENT/34"
+void test_ari_cbor_encode_objref_path_int(bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id, const char *expect)
+{
+    ari_t ari = ARI_INIT_UNDEFINED;
+    ari_set_objref_path_intid_opt(&ari, has_ns, ns_id, has_type, type_id, has_obj, obj_id);
+
+    check_encoding(&ari, expect);
+
+    ari_deinit(&ari);
+}
+
 static void check_decoding(ari_t *ari, const char *inhex)
 {
     string_t intext;
@@ -181,6 +236,20 @@ static void check_decoding(ari_t *ari, const char *inhex)
     TEST_ASSERT_EQUAL_INT_MESSAGE(inlen, used, "ari_cbor_decode() did not use all data");
 
     TEST_ASSERT_TRUE_MESSAGE(amm_builtin_validate(ari), "amm_builtin_validate() failed");
+}
+
+TEST_CASE("8312201822", 18, ARI_TYPE_IDENT, 34)
+void test_ari_cbor_decode_objref_path(const char *hexval, int64_t ns_id, ari_type_t type_id, int64_t obj_id)
+{
+    ari_t ari = ARI_INIT_UNDEFINED;
+
+    check_decoding(&ari, hexval);
+    TEST_ASSERT_TRUE(ari.is_ref);
+    TEST_ASSERT_EQUAL_INT(ns_id, ari.as_ref.objpath.ns_id.as_int);
+    TEST_ASSERT_EQUAL_INT(type_id, ari.as_ref.objpath.type_id.as_int);
+    TEST_ASSERT_EQUAL_INT(obj_id, ari.as_ref.objpath.obj_id.as_int);
+
+    ari_deinit(&ari);
 }
 
 void test_ari_cbor_decode_lit_prim_undef(void)

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -160,10 +160,8 @@ void test_ari_cbor_encode_lit_typed_ac_1item(void)
     }
 }
 
-/*
+/* TODO:
 
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://adm/"):INFO: Encoded hex: 836361646DF6F6
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://adm/"):FAIL: parser error 3
 /home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://example-adm-a@2024-06-25/"):INFO: Encoded hex: 8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6
 /home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://example-adm-a@2024-06-25/"):FAIL: parser error 3
 /home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://example-adm-a/"):INFO: Encoded hex: 836D6578616D706C652D61646D2D61F6F6
@@ -174,25 +172,20 @@ void test_ari_cbor_encode_lit_typed_ac_1item(void)
 /home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://65536/"):FAIL: parser error 3
 /home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://-20/"):INFO: Encoded hex: 8333F6F6
 /home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://-20/"):FAIL: parser error 3
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://test/CONST/that"):INFO: Encoded hex: 836474657374216474686174
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://test/CONST/that"):PASS
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://test@1234/CONST/that"):INFO: Encoded hex: 8369746573744031323334216474686174
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://test@1234/CONST/that"):PASS
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://!test/CONST/that"):INFO: Encoded hex: 83652174657374216474686174
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://!test/CONST/that"):PASS
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://test/CTRL/that(34)"):INFO: Encoded hex: 846474657374226474686174811822
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://test/CTRL/that(34)"):PASS
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://2/CTRL/4(hi)"):INFO: Encoded hex: 8402220481626869
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://2/CTRL/4(hi)"):PASS
+
 */
 
-
-TEST_CASE(NULL, ARI_TYPE_CONST, "hi", "83F621626869") // "./CONST/hi"
-TEST_CASE("adm", ARI_TYPE_CONST, "hi", "836361646D21626869") // "ari://adm/CONST/hi"
-void test_ari_cbor_encode_objref_path_text(const char *ns_id, ari_type_t type_id, const char *obj_id, const char *expect)
+TEST_CASE("adm", false, 0, NULL, "836361646D00F6") // "ari://adm/"
+TEST_CASE(NULL, true, ARI_TYPE_CONST, "hi", "83F621626869") // "./CONST/hi"
+TEST_CASE("adm", true, ARI_TYPE_CONST, "hi", "836361646D21626869") // "ari://adm/CONST/hi"
+TEST_CASE("test", true, ARI_TYPE_CONST, "that", "836474657374216474686174") // "ari://test/CONST/that"
+TEST_CASE("test@1234", true, ARI_TYPE_CONST, "that", "8369746573744031323334216474686174") // "ari://test@1234/CONST/that"
+TEST_CASE("!test", true, ARI_TYPE_CONST, "that", "83652174657374216474686174") // "ari://!test/CONST/that"
+// TODO: TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // "ari://test/CTRL/that(34)"
+void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari_type_t type_id, const char *obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;
-    bool has_ns = ns_id != NULL, has_type = true, has_obj = obj_id != NULL;
+    bool has_ns = ns_id != NULL, has_obj = obj_id != NULL;
     ari_set_objref_path_textid_opt(&ari, has_ns, ns_id, has_type, type_id, has_obj, obj_id);
 
     check_encoding(&ari, expect);
@@ -205,6 +198,9 @@ void test_ari_cbor_encode_objref_path_text(const char *ns_id, ari_type_t type_id
 // TODO: TEST_CASE(true, -20, false, 0, false, 0, "8333F6F6") // "ari://-20/"
 TEST_CASE(false, 0, true, ARI_TYPE_IDENT, true, 34, "83F6201822") // "./IDENT/34"
 TEST_CASE(true, 18, true, ARI_TYPE_IDENT, true, 34, "8312201822") // "ari://18/IDENT/34"
+// TODO:
+///home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://2/CTRL/4(hi)"):INFO: Encoded hex: 8402220481626869
+///home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://2/CTRL/4(hi)"):PASS
 void test_ari_cbor_encode_objref_path_int(bool has_ns, int64_t ns_id, bool has_type, ari_type_t type_id, bool has_obj, int64_t obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -160,28 +160,16 @@ void test_ari_cbor_encode_lit_typed_ac_1item(void)
     }
 }
 
-/* TODO:
-
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://example-adm-a@2024-06-25/"):INFO: Encoded hex: 8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://example-adm-a@2024-06-25/"):FAIL: parser error 3
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://example-adm-a/"):INFO: Encoded hex: 836D6578616D706C652D61646D2D61F6F6
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://example-adm-a/"):FAIL: parser error 3
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://!example-odm-b/"):INFO: Encoded hex: 836E216578616D706C652D6F646D2D62F6F6
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://!example-odm-b/"):FAIL: parser error 3
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://65536/"):INFO: Encoded hex: 831A00010000F6F6
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://65536/"):FAIL: parser error 3
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://-20/"):INFO: Encoded hex: 8333F6F6
-/home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:146:test_ari_text_loopback("ari://-20/"):FAIL: parser error 3
-
-*/
-
-TEST_CASE("adm", false, 0, NULL, "836361646D00F6") // "ari://adm/"
-TEST_CASE(NULL, true, ARI_TYPE_CONST, "hi", "83F621626869") // "./CONST/hi"
-TEST_CASE("adm", true, ARI_TYPE_CONST, "hi", "836361646D21626869") // "ari://adm/CONST/hi"
-TEST_CASE("test", true, ARI_TYPE_CONST, "that", "836474657374216474686174") // "ari://test/CONST/that"
-TEST_CASE("test@1234", true, ARI_TYPE_CONST, "that", "8369746573744031323334216474686174") // "ari://test@1234/CONST/that"
-TEST_CASE("!test", true, ARI_TYPE_CONST, "that", "83652174657374216474686174") // "ari://!test/CONST/that"
-// TODO: TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // "ari://test/CTRL/that(34)"
+TEST_CASE("example-adm-a@2024-06-25", false, 0, NULL, "8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6") // ari://example-adm-a@2024-06-25/
+TEST_CASE("example-adm-a", false, 0, NULL, "836D6578616D706C652D61646D2D61F6F6") // ari://example-adm-a/
+TEST_CASE("!example-odm-b", false, 0, NULL, "836E216578616D706C652D6F646D2D62F6F6") // ari://!example-odm-b/
+TEST_CASE("adm", false, 0, NULL, "836361646DF6F6") // ari://adm/
+TEST_CASE(NULL, true, ARI_TYPE_CONST, "hi", "83F621626869") // "./CONST/hi
+TEST_CASE("adm", true, ARI_TYPE_CONST, "hi", "836361646D21626869") // ari://adm/CONST/hi
+TEST_CASE("test", true, ARI_TYPE_CONST, "that", "836474657374216474686174") // ari://test/CONST/that
+TEST_CASE("test@1234", true, ARI_TYPE_CONST, "that", "8369746573744031323334216474686174") // ari://test@1234/CONST/that
+TEST_CASE("!test", true, ARI_TYPE_CONST, "that", "83652174657374216474686174") // ari://!test/CONST/that
+// TODO: TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // ari://test/CTRL/that(34)
 void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari_type_t type_id, const char *obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;
@@ -193,11 +181,11 @@ void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari
     ari_deinit(&ari);
 }
 
-//TEST_CASE(true, 18, false, 0, false, 0, "8312F6F6") // "ari://18/"
-//TEST_CASE(true, 65536, false, 0, false, 0, "831A00010000F6F6") // "ari://65536/"
-// TODO: TEST_CASE(true, -20, false, 0, false, 0, "8333F6F6") // "ari://-20/"
-TEST_CASE(false, 0, true, ARI_TYPE_IDENT, true, 34, "83F6201822") // "./IDENT/34"
-TEST_CASE(true, 18, true, ARI_TYPE_IDENT, true, 34, "8312201822") // "ari://18/IDENT/34"
+TEST_CASE(true, 18, false, 0, false, 0, "8312F6F6") // ari://18/
+TEST_CASE(true, 65536, false, 0, false, 0, "831A00010000F6F6") // ari://65536/
+TEST_CASE(true, -20, false, 0, false, 0, "8333F6F6") // ari://-20/
+TEST_CASE(false, 0, true, ARI_TYPE_IDENT, true, 34, "83F6201822") // ./IDENT/34
+TEST_CASE(true, 18, true, ARI_TYPE_IDENT, true, 34, "8312201822") // ari://18/IDENT/34
 // TODO:
 ///home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:138:test_ari_text_loopback("ari://2/CTRL/4(hi)"):INFO: Encoded hex: 8402220481626869
 ///home/ethieja1/dtn/dtnma-tools/test/cace/test_ari_text_cbor_loopback.c:108:test_ari_text_loopback("ari://2/CTRL/4(hi)"):PASS
@@ -234,8 +222,27 @@ static void check_decoding(ari_t *ari, const char *inhex)
     TEST_ASSERT_TRUE_MESSAGE(amm_builtin_validate(ari), "amm_builtin_validate() failed");
 }
 
+TEST_CASE("836361646D21626869", "adm", ARI_TYPE_CONST, "hi") // ari://adm/CONST/hi
+TEST_CASE("836474657374216474686174", "test", ARI_TYPE_CONST, "that") // "ari://test/CONST/that
+TEST_CASE("8369746573744031323334216474686174", "test@1234", ARI_TYPE_CONST, "that") // ari://test@1234/CONST/that
+TEST_CASE("83652174657374216474686174", "!test", ARI_TYPE_CONST, "that") // ari://!test/CONST/that
+TEST_CASE("846474657374226474686174811822", "test", ARI_TYPE_CTRL, "that") // ari://test/CTRL/that(34)
+void test_ari_cbor_decode_objref_path_text(const char *hexval, const char *ns_id, ari_type_t type_id, const char *obj_id)
+{
+    ari_t ari = ARI_INIT_UNDEFINED;
+
+    check_decoding(&ari, hexval);
+    TEST_ASSERT_TRUE(ari.is_ref);
+    TEST_ASSERT_EQUAL_STRING(ns_id, ari.as_ref.objpath.ns_id.as_text);
+    TEST_ASSERT_EQUAL_INT(type_id, ari.as_ref.objpath.type_id.as_int);
+    TEST_ASSERT_EQUAL_STRING(obj_id, ari.as_ref.objpath.obj_id.as_text);
+
+    ari_deinit(&ari);
+}
+
 TEST_CASE("8312201822", 18, ARI_TYPE_IDENT, 34)
-void test_ari_cbor_decode_objref_path(const char *hexval, int64_t ns_id, ari_type_t type_id, int64_t obj_id)
+TEST_CASE("8402220481626869", 2, ARI_TYPE_CTRL, 4) // ari://2/CTRL/4(hi)
+void test_ari_cbor_decode_objref_path_int(const char *hexval, int64_t ns_id, ari_type_t type_id, int64_t obj_id)
 {
     ari_t ari = ARI_INIT_UNDEFINED;
 

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -160,28 +160,6 @@ void test_ari_cbor_encode_lit_typed_ac_1item(void)
     }
 }
 
-void test_ari_cbor_encode_objref_path_text_with_param(void)
-{
-//TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // ari://test/CTRL/that(34)
-    ari_t ari = ARI_INIT_UNDEFINED;
-    ari_ac_t acinit;
-    ari_set_objref_path_textid_opt(&ari, true, "test", true, ARI_TYPE_CTRL, true, "that");
-    ari_ac_init(&acinit);
-    {
-        ari_t *item = ari_list_push_back_new(acinit.items);
-        ari_set_int(item, 34);
-    }
-
-    ari_set_objref_params_ac(&ari, &acinit);
-
-    check_encoding(&ari, "846474657374226474686174811822");
-
-//846474657374226474686174811822
-//83647465737422687468617428333429
-
-    ari_deinit(&ari);
-}
-
 TEST_CASE("example-adm-a@2024-06-25", false, 0, NULL, "8378186578616D706C652D61646D2D6140323032342D30362D3235F6F6") // ari://example-adm-a@2024-06-25/
 TEST_CASE("example-adm-a", false, 0, NULL, "836D6578616D706C652D61646D2D61F6F6") // ari://example-adm-a/
 TEST_CASE("!example-odm-b", false, 0, NULL, "836E216578616D706C652D6F646D2D62F6F6") // ari://!example-odm-b/
@@ -191,7 +169,6 @@ TEST_CASE("adm", true, ARI_TYPE_CONST, "hi", "836361646D21626869") // ari://adm/
 TEST_CASE("test", true, ARI_TYPE_CONST, "that", "836474657374216474686174") // ari://test/CONST/that
 TEST_CASE("test@1234", true, ARI_TYPE_CONST, "that", "8369746573744031323334216474686174") // ari://test@1234/CONST/that
 TEST_CASE("!test", true, ARI_TYPE_CONST, "that", "83652174657374216474686174") // ari://!test/CONST/that
-TEST_CASE("test", true, ARI_TYPE_CTRL, "that(34)", "846474657374226474686174811822") // ari://test/CTRL/that(34)
 void test_ari_cbor_encode_objref_path_text(const char *ns_id, bool has_type, ari_type_t type_id, const char *obj_id, const char *expect)
 {
     ari_t ari = ARI_INIT_UNDEFINED;


### PR DESCRIPTION
Added additional test cases for references in binary form and added new helper functions for constructing objref path ARI objects.