### PR TITLE
Updates for installation on RHEL 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ civetweb
 libcivetweb-dev
 libssl-dev
 libcjson-dev
+gcovr
 ```
 
 To use the systemd wrapper utility around the executables, also install the PIP package
@@ -55,6 +56,7 @@ systemd-python
 
 Once dependencies are installed, the following scripts can be run to build and test the project:
 ```
+./deps.sh
 ./prep.sh
 ./build.sh check
 ```

--- a/README.md
+++ b/README.md
@@ -54,9 +54,16 @@ To use the systemd wrapper utility around the executables, also install the PIP 
 systemd-python
 ```
 
+In addition to the above, this project also has dependencies provided as git submodules. These may be retrieved and built using the following commands:
+
+```
+git submodule init
+git submodule update --recursive
+./deps.sh
+```
+
 Once dependencies are installed, the following scripts can be run to build and test the project:
 ```
-./deps.sh
 ./prep.sh
 ./build.sh check
 ```

--- a/deps.sh
+++ b/deps.sh
@@ -54,6 +54,7 @@ then
   pushd ${DEPSDIR}/QCBOR
   cmake -S . -B ${BUILDDIR}/QCBOR \
     -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_C_FLAGS="-fPIC " \
     -DCMAKE_INSTALL_PREFIX=${DESTDIR}${PREFIX}
   cmake --build ${BUILDDIR}/QCBOR
   cmake --install ${BUILDDIR}/QCBOR


### PR DESCRIPTION
Updated `devs.sh` to explicitly pass `-fPIC` to `CFLAGS`. This prevents a linking error when building on RHEL 9.

Updated Readme to include new script / dep in RHEL 9.