### PR TITLE
Fixing declarations to allow using CACE and REFDA linked from C++ sources

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -64,7 +64,7 @@ jobs:
           dnf install -y \
               git rsync \
               cmake ninja-build \
-              ruby gcc ccache autoconf libtool \
+              ruby gcc g++ ccache autoconf libtool \
               flex libfl-static bison pcre2-devel civetweb civetweb-devel openssl-devel cjson-devel \
               valgrind xmlstarlet python3-pip
           pip3 install gcovr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ STRING(REGEX REPLACE [[^v([0-9]+\.[0-9]+\.[0-9]+).*]] [[\1]] GIT_TAG_VERS "${GIT
 message(STATUS "Using git label ${GIT_TAG_REV} to version ${GIT_TAG_VERS}")
 
 project(nm
-    LANGUAGES C
     VERSION ${GIT_TAG_VERS}
 )
 
@@ -60,6 +59,10 @@ add_definitions(
   -D_XOPEN_SOURCE
   -D_POSIX_C_SOURCE=200809L
 )
+# CXX used for compilation tests
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Generic warn/error options
 add_compile_options(

--- a/apply_license.sh
+++ b/apply_license.sh
@@ -29,7 +29,7 @@ set -e
 SELFDIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 
 LICENSEOPTS="${LICENSEOPTS} --tmpl ${SELFDIR}/apply_license.tmpl"
-LICENSEOPTS="${LICENSEOPTS} --years 2011-$(date +%Y)"
+LICENSEOPTS="${LICENSEOPTS} --years 2011-2024"
 # Excludes only apply to directory (--dir) mode and not file mode
 LICENSEOPTS="${LICENSEOPTS} --exclude *.yml *.yaml *.min.* "
 

--- a/deps.sh
+++ b/deps.sh
@@ -84,6 +84,7 @@ fi
 if [ ! -e ${DESTDIR}/usr/include/m-lib ]
 then
   echo "Building MLIB..."
+  mkdir -p ${BUILDDIR}/mlib/
   rsync --recursive ${DEPSDIR}/mlib/ ${BUILDDIR}/mlib/
   pushd ${BUILDDIR}/mlib
   

--- a/memcheck.supp
+++ b/memcheck.supp
@@ -46,7 +46,6 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:realloc
-   fun:_ari_type_by_id_array_list_pair_resize
    fun:m_d1ct__ari_type_by_id_resize_up
    fun:_ari_type_by_id_set_at
    fun:_ari_type_dict_init
@@ -56,8 +55,7 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:realloc
-   fun:_ari_type_by_name_array_list_pair_resize
-   fun:m_d1ct__ari_type_by_name_resize_up
+   fun:*_resize_up
    fun:_ari_type_by_name_set_at
    fun:_ari_type_dict_init
 }
@@ -76,7 +74,7 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:malloc
-   fun:m_l1st__ari_type_by_name_list_pair_new
+   fun:*_pair_new
    fun:_ari_type_by_name_list_pair_push_raw
    fun:_ari_type_by_name_set_at
    fun:_ari_type_dict_init
@@ -86,8 +84,7 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:realloc
-   fun:amm_type_lookup_array_list_pair_resize
-   fun:m_d1ct_amm_type_lookup_resize_up
+   fun:*_resize_up
    fun:amm_type_lookup_set_at
    fun:amm_builtin_dict_init
 }
@@ -96,7 +93,7 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:malloc
-   fun:m_l1st_amm_type_lookup_list_pair_new
+   fun:*_pair_new
    fun:amm_type_lookup_list_pair_push_raw
    fun:amm_type_lookup_set_at
    fun:amm_builtin_dict_init

--- a/src/cace/amm/lookup.c
+++ b/src/cace/amm/lookup.c
@@ -35,6 +35,16 @@ void cace_amm_lookup_deinit(cace_amm_lookup_t *res)
     res->obj_type = ARI_TYPE_NULL;
 }
 
+void cace_amm_lookup_init_set(cace_amm_lookup_t *res, const cace_amm_lookup_t *src)
+{
+    CHKVOID(res);
+    CHKVOID(src);
+    res->ns       = src->ns;
+    res->obj      = src->obj;
+    res->obj_type = src->obj_type;
+    cace_ari_itemized_init_set(&(res->aparams), &(src->aparams));
+}
+
 void cace_amm_lookup_init_move(cace_amm_lookup_t *res, cace_amm_lookup_t *src)
 {
     CHKVOID(res);
@@ -46,6 +56,12 @@ void cace_amm_lookup_init_move(cace_amm_lookup_t *res, cace_amm_lookup_t *src)
     res->obj_type = src->obj_type;
     src->obj_type = ARI_TYPE_NULL;
     cace_ari_itemized_init_move(&(res->aparams), &(src->aparams));
+}
+
+void cace_amm_lookup_set(cace_amm_lookup_t *res, const cace_amm_lookup_t *src)
+{
+    cace_amm_lookup_deinit(res);
+    cace_amm_lookup_init_set(res, src);
 }
 
 void cace_amm_lookup_set_move(cace_amm_lookup_t *res, cace_amm_lookup_t *src)

--- a/src/cace/amm/lookup.h
+++ b/src/cace/amm/lookup.h
@@ -47,13 +47,25 @@ typedef struct
 
 } cace_amm_lookup_t;
 
+/** State initializer.
+ */
 void cace_amm_lookup_init(cace_amm_lookup_t *res);
 
+/** State de-initializer.
+ */
 void cace_amm_lookup_deinit(cace_amm_lookup_t *res);
+
+/** Initializer with copy semantics.
+ */
+void cace_amm_lookup_init_set(cace_amm_lookup_t *res, const cace_amm_lookup_t *src);
 
 /** Initializer with move semantics.
  */
 void cace_amm_lookup_init_move(cace_amm_lookup_t *res, cace_amm_lookup_t *src);
+
+/** Setter with copy semantics.
+ */
+void cace_amm_lookup_set(cace_amm_lookup_t *res, const cace_amm_lookup_t *src);
 
 /** Setter with move semantics.
  */

--- a/src/cace/amm/obj_desc.h
+++ b/src/cace/amm/obj_desc.h
@@ -29,7 +29,7 @@ extern "C" {
 
 /** A generic object descriptor common to all AMM object types in an Agent.
  */
-typedef struct
+typedef struct cace_amm_obj_desc_s
 {
     /// Indication of whether this object has an enumeration assigned
     bool has_enum;
@@ -45,13 +45,19 @@ typedef struct
      */
     cace_amm_user_data_t app_data;
 
+#ifdef __cplusplus
+    cace_amm_obj_desc_s(const cace_amm_obj_desc_s &)            = delete;
+    cace_amm_obj_desc_s &operator=(const cace_amm_obj_desc_s &) = delete;
+#endif
+
 } cace_amm_obj_desc_t;
 
 void cace_amm_obj_desc_init(cace_amm_obj_desc_t *obj);
 
 void cace_amm_obj_desc_deinit(cace_amm_obj_desc_t *obj);
 
-#define M_OPL_cace_amm_obj_desc_t() (INIT(API_2(cace_amm_obj_desc_init)), CLEAR(API_2(cace_amm_obj_desc_deinit)))
+#define M_OPL_cace_amm_obj_desc_t() \
+    (INIT(API_2(cace_amm_obj_desc_init)), INIT_SET(0), SET(0), CLEAR(API_2(cace_amm_obj_desc_deinit)))
 
 #ifdef __cplusplus
 } // extern C

--- a/src/cace/amm/obj_ns.c
+++ b/src/cace/amm/obj_ns.c
@@ -49,6 +49,23 @@ void cace_amm_obj_ns_deinit(cace_amm_obj_ns_t *ns)
     m_string_clear(ns->name);
 }
 
+cace_amm_obj_id_t cace_amm_obj_id_withenum(const char *name, int64_t intenum)
+{
+    return (cace_amm_obj_id_t) {
+        .name     = name,
+        .has_enum = true,
+        .intenum  = intenum,
+    };
+}
+
+cace_amm_obj_id_t cace_amm_obj_id_noenum(const char *name)
+{
+    return (cace_amm_obj_id_t) {
+        .name     = name,
+        .has_enum = false,
+    };
+}
+
 cace_amm_obj_desc_t *cace_amm_obj_ns_add_obj(cace_amm_obj_ns_t *ns, ari_type_t obj_type, const cace_amm_obj_id_t obj_id)
 {
     if (cace_log_is_enabled_for(LOG_DEBUG))
@@ -82,7 +99,8 @@ cace_amm_obj_desc_t *cace_amm_obj_ns_add_obj(cace_amm_obj_ns_t *ns, ari_type_t o
         }
     }
 
-    cace_amm_obj_desc_t *obj = cace_amm_obj_desc_list_push_back_new(ctr->obj_list);
+    cace_amm_obj_desc_ptr_t **ptr = cace_amm_obj_desc_list_push_back_new(ctr->obj_list);
+    cace_amm_obj_desc_t      *obj = cace_amm_obj_desc_ptr_ref(*ptr);
     string_set_str(obj->name, obj_id.name);
     obj->has_enum = obj_id.has_enum;
     obj->intenum  = obj_id.intenum;

--- a/src/cace/amm/obj_ns.h
+++ b/src/cace/amm/obj_ns.h
@@ -21,6 +21,7 @@
 #include "obj_desc.h"
 #include "cace/util/nocase.h"
 #include <m-rbtree.h>
+#include <m-shared-ptr.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,8 +36,10 @@ extern "C" {
  * list members.
  */
 /// @cond Doxygen_Suppress
-RBTREE_DEF(string_tree_set, m_string_t)
-DEQUE_DEF(cace_amm_obj_desc_list, cace_amm_obj_desc_t)
+M_RBTREE_DEF(string_tree_set, m_string_t)
+M_SHARED_WEAK_PTR_DEF(cace_amm_obj_desc_ptr, cace_amm_obj_desc_t)
+M_DEQUE_DEF(cace_amm_obj_desc_list, cace_amm_obj_desc_ptr_t *,
+            M_SHARED_PTR_OPLIST(cace_amm_obj_desc_ptr, M_OPL_cace_amm_obj_desc_t()))
 M_BPTREE_DEF2(cace_amm_obj_desc_by_enum, 4, int64_t, M_BASIC_OPLIST, cace_amm_obj_desc_t *, M_PTR_OPLIST)
 M_BPTREE_DEF2(cace_amm_obj_desc_by_name, 4, const char *, M_CSTR_NOCASE_OPLIST, cace_amm_obj_desc_t *, M_PTR_OPLIST)
 /// @endcond
@@ -56,8 +59,13 @@ void cace_amm_obj_ns_ctr_deinit(cace_amm_obj_ns_ctr_t *obj);
 
 #define M_OPL_cace_amm_obj_ns_ctr_t() (INIT(API_2(cace_amm_obj_ns_ctr_init)), CLEAR(API_2(cace_amm_obj_ns_ctr_deinit)))
 
+/** @struct cace_amm_obj_ns_ctr_dict_t
+ * A mapping from ari_type_t integer enumeration to cace_amm_obj_ns_ctr_t
+ * object containers.
+ */
 /// @cond Doxygen_Suppress
-M_DICT_DEF2(cace_amm_obj_ns_ctr_dict, ari_type_t, M_BASIC_OPLIST, cace_amm_obj_ns_ctr_t, M_OPL_cace_amm_obj_ns_ctr_t())
+M_DICT_DEF2(cace_amm_obj_ns_ctr_dict, ari_type_t, M_OPL_ari_type_t(), cace_amm_obj_ns_ctr_t,
+            M_OPL_cace_amm_obj_ns_ctr_t())
 /// @endcond
 
 typedef struct
@@ -98,22 +106,9 @@ typedef struct
  * @param The object enumeration.
  * @return The full object ID.
  */
-static inline cace_amm_obj_id_t cace_amm_obj_id_withenum(const char *name, int64_t intenum)
-{
-    return (cace_amm_obj_id_t) {
-        .name     = name,
-        .has_enum = true,
-        .intenum  = intenum,
-    };
-}
+cace_amm_obj_id_t cace_amm_obj_id_withenum(const char *name, int64_t intenum);
 /// @overload
-static inline cace_amm_obj_id_t cace_amm_obj_id_noenum(const char *name)
-{
-    return (cace_amm_obj_id_t) {
-        .name     = name,
-        .has_enum = false,
-    };
-}
+cace_amm_obj_id_t cace_amm_obj_id_noenum(const char *name);
 
 cace_amm_obj_desc_t *cace_amm_obj_ns_add_obj(cace_amm_obj_ns_t *ns, ari_type_t obj_type,
                                              const cace_amm_obj_id_t obj_id);

--- a/src/cace/amm/user_data.h
+++ b/src/cace/amm/user_data.h
@@ -32,7 +32,7 @@ extern "C" {
  */
 typedef void (*cace_amm_user_data_deinit_f)(void *ptr);
 
-typedef struct
+typedef struct cace_amm_user_data_s
 {
     /// Pointer to the opaque user data being managed
     void *ptr;
@@ -42,6 +42,12 @@ typedef struct
     bool owned;
     /// An optional cleanup function for the #ptr.
     cace_amm_user_data_deinit_f deinit;
+
+#ifdef __cplusplus
+    cace_amm_user_data_s(const cace_amm_user_data_s &)            = delete;
+    cace_amm_user_data_s &operator=(const cace_amm_user_data_s &) = delete;
+#endif
+
 } cace_amm_user_data_t;
 
 void cace_amm_user_data_init(cace_amm_user_data_t *obj);

--- a/src/cace/ari/itemized.c
+++ b/src/cace/ari/itemized.c
@@ -25,6 +25,14 @@ void cace_ari_itemized_init(cace_ari_itemized_t *obj)
     named_ari_ptr_dict_init(obj->named);
 }
 
+void cace_ari_itemized_init_set(cace_ari_itemized_t *obj, const cace_ari_itemized_t *src)
+{
+    CHKVOID(obj);
+    CHKVOID(src);
+    ari_array_init_set(obj->ordered, src->ordered);
+    named_ari_ptr_dict_init_set(obj->named, src->named);
+}
+
 void cace_ari_itemized_init_move(cace_ari_itemized_t *obj, cace_ari_itemized_t *src)
 {
     CHKVOID(obj);

--- a/src/cace/ari/itemized.h
+++ b/src/cace/ari/itemized.h
@@ -49,8 +49,16 @@ typedef struct
  */
 void cace_ari_itemized_init(cace_ari_itemized_t *obj);
 
+/** Initializer with copy semantics.
+ */
+void cace_ari_itemized_init_set(cace_ari_itemized_t *obj, const cace_ari_itemized_t *src);
+
+/** Initializer with move semantics.
+ */
 void cace_ari_itemized_init_move(cace_ari_itemized_t *obj, cace_ari_itemized_t *src);
 
+/** State de-initializer.
+ */
 void cace_ari_itemized_deinit(cace_ari_itemized_t *obj);
 
 /** Clear out any parameters present.

--- a/src/cace/ari/type.h
+++ b/src/cace/ari/type.h
@@ -96,6 +96,10 @@ const char *ari_type_to_name(int32_t typenum);
  */
 int ari_type_from_name(int32_t *typenum, const char *name);
 
+/** M*LIB OPLIST for the enum ari_type_t.
+ */
+#define M_OPL_ari_type_t() M_ENUM_OPLIST(ari_type_t, ARI_TYPE_NULL)
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cace/config.h.in
+++ b/src/cace/config.h.in
@@ -23,6 +23,7 @@
 #define CACE_CONFIG_H_
 
 #ifdef __cplusplus
+#include <cstdlib>
 extern "C" {
 #endif
 
@@ -62,20 +63,20 @@ extern "C" {
 /** Define to override value/struct allocation.
  * See m-core.h for details.
  */
-#define M_MEMORY_ALLOC(type) ARI_MALLOC(sizeof(type));
+#define M_MEMORY_ALLOC(type) ((type *) ARI_MALLOC(sizeof(type)))
 /** Define to override value/struct deallocation.
  * See m-core.h for details.
  */
-#define M_MEMORY_DEL(ptr) ARI_FREE(ptr);
+#define M_MEMORY_DEL(ptr) ARI_FREE(ptr)
 
 /** Define to override array allocation.
  * See m-core.h for details.
  */
-#define M_MEMORY_REALLOC(type, ptr, n) (M_UNLIKELY((n) > SIZE_MAX / sizeof(type)) ? NULL : ARI_REALLOC((ptr), (n)*sizeof (type)))
+#define M_MEMORY_REALLOC(type, ptr, n) (M_UNLIKELY((n) > SIZE_MAX / sizeof(type)) ? (type *) NULL : (type *) ARI_REALLOC((ptr), (n)*sizeof (type)))
 /** Define to override array deallocation.
  * See m-core.h for details.
  */
-#define M_MEMORY_FREE(ptr) ARI_FREE(ptr);
+#define M_MEMORY_FREE(ptr) ARI_FREE(ptr)
 
 #ifdef __cplusplus
 } // extern C

--- a/src/refda-stdio/main.c
+++ b/src/refda-stdio/main.c
@@ -29,6 +29,7 @@
 
 #define MAX_HEXMSG_SIZE 10240
 
+/// Per-process state
 static refda_agent_t agent;
 
 static void daemon_signal_handler(int signum)

--- a/src/refda/adm/ietf_dtnma_agent.c
+++ b/src/refda/adm/ietf_dtnma_agent.c
@@ -467,7 +467,7 @@ static void refda_adm_ietf_dtnma_agent_edd_typedef_list(refda_edd_prod_ctx_t *ct
         for (cace_amm_obj_desc_list_it(obj_it, ctr->obj_list); !cace_amm_obj_desc_list_end_p(obj_it);
              cace_amm_obj_desc_list_next(obj_it))
         {
-            const cace_amm_obj_desc_t *obj = cace_amm_obj_desc_list_cref(obj_it);
+            const cace_amm_obj_desc_t *obj = cace_amm_obj_desc_ptr_ref(*cace_amm_obj_desc_list_cref(obj_it));
 
             ari_array_t row;
             ari_array_init(row);
@@ -547,7 +547,7 @@ static void refda_adm_ietf_dtnma_agent_edd_const_list(refda_edd_prod_ctx_t *ctx)
         for (cace_amm_obj_desc_list_it(obj_it, ctr->obj_list); !cace_amm_obj_desc_list_end_p(obj_it);
              cace_amm_obj_desc_list_next(obj_it))
         {
-            const cace_amm_obj_desc_t *obj = cace_amm_obj_desc_list_cref(obj_it);
+            const cace_amm_obj_desc_t *obj = cace_amm_obj_desc_ptr_ref(*cace_amm_obj_desc_list_cref(obj_it));
 
             ari_array_t row;
             ari_array_init(row);
@@ -628,7 +628,7 @@ static void refda_adm_ietf_dtnma_agent_edd_var_list(refda_edd_prod_ctx_t *ctx)
         for (cace_amm_obj_desc_list_it(obj_it, ctr->obj_list); !cace_amm_obj_desc_list_end_p(obj_it);
              cace_amm_obj_desc_list_next(obj_it))
         {
-            const cace_amm_obj_desc_t *obj = cace_amm_obj_desc_list_cref(obj_it);
+            const cace_amm_obj_desc_t *obj = cace_amm_obj_desc_ptr_ref(*cace_amm_obj_desc_list_cref(obj_it));
 
             ari_array_t row;
             ari_array_init(row);

--- a/src/refda/agent.c
+++ b/src/refda/agent.c
@@ -170,7 +170,7 @@ int refda_agent_bindrefs(refda_agent_t *agent)
             for (cace_amm_obj_desc_list_it(obj_it, obj_ctr->obj_list); !cace_amm_obj_desc_list_end_p(obj_it);
                  cace_amm_obj_desc_list_next(obj_it))
             {
-                cace_amm_obj_desc_t *obj = cace_amm_obj_desc_list_ref(obj_it);
+                cace_amm_obj_desc_t *obj = cace_amm_obj_desc_ptr_ref(*cace_amm_obj_desc_list_ref(obj_it));
 
                 const int objfailcnt = refda_binding_obj(obj_type, obj, &(agent->objs));
                 if (objfailcnt)

--- a/src/refda/exec_item.c
+++ b/src/refda/exec_item.c
@@ -28,6 +28,17 @@ void refda_exec_item_init(refda_exec_item_t *obj)
     ari_init(&(obj->result));
 }
 
+void refda_exec_item_init_set(refda_exec_item_t *obj, const refda_exec_item_t *src)
+{
+    CHKVOID(obj);
+    CHKVOID(src);
+    obj->seq = NULL;
+    ari_init_copy(&(obj->ref), &(src->ref));
+    cace_amm_lookup_init_set(&(obj->deref), &(src->deref));
+    atomic_init(&(obj->waiting), atomic_load(&(src->waiting)));
+    ari_init_copy(&(obj->result), &(src->result));
+}
+
 void refda_exec_item_deinit(refda_exec_item_t *obj)
 {
     CHKVOID(obj);
@@ -35,4 +46,15 @@ void refda_exec_item_deinit(refda_exec_item_t *obj)
     cace_amm_lookup_deinit(&(obj->deref));
     ari_deinit(&(obj->ref));
     obj->seq = NULL;
+}
+
+void refda_exec_item_set(refda_exec_item_t *obj, const refda_exec_item_t *src)
+{
+    CHKVOID(obj);
+    CHKVOID(src);
+    obj->seq = src->seq;
+    ari_set_copy(&(obj->ref), &(src->ref));
+    cace_amm_lookup_set(&(obj->deref), &(src->deref));
+    atomic_store(&(obj->waiting), atomic_load(&(src->waiting)));
+    ari_set_copy(&(obj->result), &(src->result));
 }

--- a/src/refda/exec_item.h
+++ b/src/refda/exec_item.h
@@ -60,12 +60,26 @@ typedef struct
 
 } refda_exec_item_t;
 
+/** Interface for M*LIB use.
+ */
 void refda_exec_item_init(refda_exec_item_t *obj);
 
+/** Interface for M*LIB use.
+ */
+void refda_exec_item_init_set(refda_exec_item_t *obj, const refda_exec_item_t *src);
+
+/** Interface for M*LIB use.
+ */
 void refda_exec_item_deinit(refda_exec_item_t *obj);
 
+/** Interface for M*LIB use.
+ */
+void refda_exec_item_set(refda_exec_item_t *obj, const refda_exec_item_t *src);
+
 /// M*LIB OPLIST for refda_exec_item_t
-#define M_OPL_refda_exec_item_t() (INIT(API_2(refda_exec_item_init)), CLEAR(API_2(refda_exec_item_deinit)))
+#define M_OPL_refda_exec_item_t()                                                                                   \
+    (INIT(API_2(refda_exec_item_init)), INIT_SET(API_6(refda_exec_item_init_set)), SET(API_6(refda_exec_item_set)), \
+     CLEAR(API_2(refda_exec_item_deinit)))
 
 #ifdef __cplusplus
 } // extern C

--- a/test/cace/CMakeLists.txt
+++ b/test/cace/CMakeLists.txt
@@ -45,3 +45,8 @@ target_link_libraries(test_amm_obj_ns PUBLIC cace)
 
 add_unity_test(SOURCE "test_amm_lookup.c")
 target_link_libraries(test_amm_lookup PUBLIC cace)
+
+# Test just being able to compile and link a C++ user with the cace library
+add_executable(test_cace_cpp)
+target_sources(test_cace_cpp PRIVATE test_cace_cpp.cpp)
+target_link_libraries(test_cace_cpp PUBLIC cace)

--- a/test/cace/test_cace_cpp.cpp
+++ b/test/cace/test_cace_cpp.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2024 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Delay-Tolerant Networking Management
+ * Architecture (DTNMA) Tools package.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @file
+ * This just verifies the ability for a C++11 executable to link with the
+ * cace library.
+ */
+
+#include <cace/ari.h>
+#include <cace/util/defs.h>
+#include <iostream>
+
+int main(int argc _U_, char *argv[] _U_)
+{
+    ari_t value;
+    ari_init(&value);
+
+    ari_deinit(&value);
+    return 0;
+}

--- a/test/refda/CMakeLists.txt
+++ b/test/refda/CMakeLists.txt
@@ -33,3 +33,8 @@ target_link_libraries(test_reporting PUBLIC refda test_util)
 
 add_unity_test(SOURCE "test_adm_ietf_dtnma_agent.c")
 target_link_libraries(test_adm_ietf_dtnma_agent PUBLIC refda test_util)
+
+# Test just being able to compile and link a C++ user with the refda library
+add_executable(test_refda_cpp)
+target_sources(test_refda_cpp PRIVATE test_refda_cpp.cpp)
+target_link_libraries(test_refda_cpp PUBLIC refda)

--- a/test/refda/test_refda_cpp.cpp
+++ b/test/refda/test_refda_cpp.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2011-2024 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Delay-Tolerant Networking Management
+ * Architecture (DTNMA) Tools package.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @file
+ * This just verifies the ability for a C++11 executable to link with the
+ * refda library.
+ */
+#include <refda/agent.h>
+#include <refda/adm/ietf_amm.h>
+#include <refda/adm/ietf_dtnma_agent.h>
+#include <cace/util/logging.h>
+#include <cace/util/defs.h>
+#include <iostream>
+
+/// Per-process state
+static refda_agent_t agent;
+
+static int dummy_send(const ari_list_t data, const cace_amm_msg_if_metadata_t *meta, void *ctx _U_)
+{
+    CHKERR1(data);
+    CHKERR1(meta);
+    CACE_LOG_DEBUG("Sending message with %d ARIs", ari_list_size(data));
+    return 0;
+}
+
+static int dummy_recv(ari_list_t data, cace_amm_msg_if_metadata_t *meta, daemon_run_t *running, void *ctx _U_)
+{
+    CHKERR1(data);
+    CHKERR1(meta);
+    CHKERR1(running);
+    CACE_LOG_DEBUG("returning due to hangup");
+    return 2;
+}
+
+int main(int argc _U_, char *argv[] _U_)
+{
+    // keep track of failure state
+    int retval = 0;
+
+    cace_openlog();
+    refda_agent_init(&agent);
+
+    int log_limit = LOG_INFO;
+    cace_log_set_least_severity(log_limit);
+    CACE_LOG_DEBUG("Agent starting up with log limit %d", log_limit);
+
+    agent.mif.send = dummy_send;
+    agent.mif.recv = dummy_recv;
+
+    // ADM initialization
+    refda_adm_ietf_amm_init(&agent);
+    refda_adm_ietf_dtnma_agent_init(&agent);
+
+    /* Start agent threads. */
+    if (!retval)
+    {
+        int failures = refda_agent_bindrefs(&agent);
+        if (failures)
+        {
+            // Warn but continue on
+            CACE_LOG_WARNING("ADM reference binding failed for %d type references", failures);
+        }
+        else
+        {
+            CACE_LOG_INFO("ADM reference binding succeeded");
+        }
+
+        if (refda_agent_start(&agent))
+        {
+            CACE_LOG_ERR("Agent startup failed");
+            retval = 2;
+        }
+        else
+        {
+            CACE_LOG_INFO("Agent startup completed");
+        }
+    }
+    CACE_LOG_INFO("READY");
+
+    if (!retval)
+    {
+        if (refda_agent_send_hello(&agent))
+        {
+            CACE_LOG_ERR("Agent hello failed");
+            retval = 3;
+        }
+        else
+        {
+            CACE_LOG_INFO("Sent hello report");
+        }
+    }
+
+    if (!retval)
+    {
+        // Block until stopped
+        daemon_run_wait(&agent.running);
+        CACE_LOG_INFO("Agent is shutting down");
+    }
+
+    /* Join threads and wait for them to complete. */
+    if (!retval)
+    {
+        if (refda_agent_stop(&agent))
+        {
+            CACE_LOG_ERR("Agent stop failed");
+            retval = 4;
+        }
+        else
+        {
+            CACE_LOG_INFO("Agent stopped");
+        }
+    }
+
+    /* Cleanup. */
+    CACE_LOG_DEBUG("Cleaning Agent Resources");
+    refda_agent_deinit(&agent);
+
+    CACE_LOG_DEBUG("Agent shutdown completed");
+    cace_closelog();
+    return retval;
+}


### PR DESCRIPTION
Fixing use of cace_amm_obj_desc_t container to avoid implicit strct copies.
Fixing ARI memory/init management.

Closes #95 