### PR TITLE
Use CI job matrix

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'centos-9']
-    name: Unit Test (${{matrix.os}})
+	deps: ['full', 'minimal']
+    name: Unit Test (${{matrix.os}} deps=${{matrix.deps}})
     runs-on: ubuntu-22.04
     container: ${{ matrix.os == 'centos-9' && 'quay.io/centos/centos:stream9' || null }}
     steps:
@@ -24,7 +25,7 @@ jobs:
           sudo apt-get install -y \
               cmake ninja-build \
               ruby build-essential autoconf libtool \
-              flex libfl-dev bison libpcre2-dev civetweb libcivetweb-dev libssl-dev libcjson-dev \
+              ${{matrix.deps=='full' && 'flex libfl-dev bison libpcre2-dev civetweb libcivetweb-dev libssl-dev libcjson-dev'}} \
               valgrind gcovr xmlstarlet
       - name: Set up OS
         if: startsWith(matrix.os, 'centos')
@@ -35,7 +36,7 @@ jobs:
               git rsync \
               cmake ninja-build \
               ruby gcc gcc-c++ ccache autoconf libtool \
-              flex libfl-static bison pcre2-devel civetweb civetweb-devel openssl-devel cjson-devel \
+              ${{matrix.deps=='full' && 'flex libfl-static bison pcre2-devel civetweb civetweb-devel openssl-devel cjson-devel'}} \
               valgrind xmlstarlet python3-pip
           pip3 install gcovr
       - name: Checkout repository
@@ -50,7 +51,7 @@ jobs:
       - name: Dependencies
         run: ./deps.sh
       - name: Prep
-        run: ./prep.sh -DBUILD_DOCS=OFF -DBUILD_TESTING=ON
+        run: ./prep.sh -DBUILD_DOCS=OFF -DBUILD_TESTING=ON -DARI_TEXT_PARSE=${{matrix.deps=='full' && 'ON' || 'OFF'}}
       - name: Build
         run: ./build.sh
       - name: Test

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   unit-test:
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-22.04', 'centos-9']
         deps: ['full', 'minimal']
@@ -61,7 +62,7 @@ jobs:
       - name: Archive coverage
         uses: actions/upload-artifact@v4
         with:
-          name: ${{github.job}}-${{matrix.os}}-coverage
+          name: ${{github.job}}-${{matrix.os}}-${{matrix.deps}}-coverage
           path: build/default/coverage*
       - name: Report coverage
         run: |

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'centos-9']
-	deps: ['full', 'minimal']
+        deps: ['full', 'minimal']
     name: Unit Test (${{matrix.os}} deps=${{matrix.deps}})
     runs-on: ubuntu-22.04
     container: ${{ matrix.os == 'centos-9' && 'quay.io/centos/centos:stream9' || null }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,16 +9,16 @@ on:
   pull_request: {} # any target
 
 jobs:
-  unit-test-ubuntu:
-    name: Unit Test (Ubuntu 22.04)
+  unit-test:
+    strategy:
+      matrix:
+        os: ['ubuntu-22.04', 'centos-9']
+    name: Unit Test (${{matrix.os}})
     runs-on: ubuntu-22.04
+    container: ${{ matrix.os == 'centos-9' && 'quay.io/centos/centos:stream9' || null }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
       - name: Set up OS
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update && \
           sudo apt-get install -y \
@@ -26,40 +26,8 @@ jobs:
               ruby build-essential autoconf libtool \
               flex libfl-dev bison libpcre2-dev civetweb libcivetweb-dev libssl-dev libcjson-dev \
               valgrind gcovr xmlstarlet
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          create-symlink: true
-      - name: Dependencies
-        run: ./deps.sh
-      - name: Prep
-        run: ./prep.sh -DBUILD_DOCS=OFF -DBUILD_TESTING=ON
-      - name: Build
-        run: ./build.sh
-      - name: Test
-        run: ./build.sh check
-      - name: Collect coverage
-        run: ./build.sh coverage
-      - name: Archive coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{github.job}}-coverage
-          path: build/default/coverage*
-      - name: Report coverage
-        run: |
-          echo "## Ubuntu 22.04 Unit Test" >> $GITHUB_STEP_SUMMARY
-          echo >> $GITHUB_STEP_SUMMARY
-          SRC_COV_PERC=$(xmlstarlet sel -t -v 'floor(/coverage/@line-rate * 100)' -n build/default/coverage-cace-xml.xml)
-          echo "CACE coverage: ${SRC_COV_PERC}%" >> $GITHUB_STEP_SUMMARY
-          SRC_COV_PERC=$(xmlstarlet sel -t -v 'floor(/coverage/@line-rate * 100)' -n build/default/coverage-refda-xml.xml)
-          echo "REFDA coverage: ${SRC_COV_PERC}%" >> $GITHUB_STEP_SUMMARY
-
-  unit-test-rhel:
-    name: Unit Test (RHEL 9)
-    runs-on: ubuntu-22.04
-    container: quay.io/centos/centos:stream9
-    steps:
       - name: Set up OS
+        if: startsWith(matrix.os, 'centos')
         run: |
           dnf config-manager --set-enabled crb
           dnf install -y epel-release
@@ -92,12 +60,10 @@ jobs:
       - name: Archive coverage
         uses: actions/upload-artifact@v4
         with:
-          name: ${{github.job}}-coverage
+          name: ${{github.job}}-${{matrix.os}}-coverage
           path: build/default/coverage*
       - name: Report coverage
         run: |
-          echo "## RHEL UBI-9 Unit Test" >> $GITHUB_STEP_SUMMARY
-          echo >> $GITHUB_STEP_SUMMARY
           SRC_COV_PERC=$(xmlstarlet sel -t -v 'floor(/coverage/@line-rate * 100)' -n build/default/coverage-cace-xml.xml)
           echo "CACE coverage: ${SRC_COV_PERC}%" >> $GITHUB_STEP_SUMMARY
           SRC_COV_PERC=$(xmlstarlet sel -t -v 'floor(/coverage/@line-rate * 100)' -n build/default/coverage-refda-xml.xml)

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y \
               cmake ninja-build \
               ruby build-essential autoconf libtool \
-              ${{matrix.deps=='full' && 'flex libfl-dev bison libpcre2-dev civetweb libcivetweb-dev libssl-dev libcjson-dev'}} \
+              ${{matrix.deps=='full' && 'flex libfl-dev bison libpcre2-dev civetweb libcivetweb-dev libssl-dev libcjson-dev' || ''}} \
               valgrind gcovr xmlstarlet
       - name: Set up OS
         if: startsWith(matrix.os, 'centos')
@@ -36,7 +36,7 @@ jobs:
               git rsync \
               cmake ninja-build \
               ruby gcc gcc-c++ ccache autoconf libtool \
-              ${{matrix.deps=='full' && 'flex libfl-static bison pcre2-devel civetweb civetweb-devel openssl-devel cjson-devel'}} \
+              ${{matrix.deps=='full' && 'flex libfl-static bison pcre2-devel civetweb civetweb-devel openssl-devel cjson-devel' || ''}} \
               valgrind xmlstarlet python3-pip
           pip3 install gcovr
       - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(BUILD_DOCS "Enable autodoc building" OFF)
 option(BUILD_AGENT "Build the Agent library and executable" ON)
 option(BUILD_MANAGER "Build the Manager library and executable" OFF) # FIXME default to ON
-option(ARI_TEXT_PARSE "Build ARI text-form parsing capability" OFF)
+option(ARI_TEXT_PARSE "Build ARI text-form parsing capability" ON)
 option(ENABLE_LUT_CACHE "Enable runtime lookup caching" ON)
 option(BUILD_TESTING "Enable test fixtures and libraries" OFF)
 option(TEST_MEMCHECK "Enable test runtime memory checking" OFF)

--- a/src/cace/amm/semtype_cnst.c
+++ b/src/cace/amm/semtype_cnst.c
@@ -59,11 +59,11 @@ cace_amm_range_size_t *amm_semtype_cnst_set_strlen(amm_semtype_cnst_t *obj)
     return cfg;
 }
 
-#if defined(PCRE_FOUND)
-
-pcre2_code *amm_semtype_cnst_set_textpat(amm_semtype_cnst_t *obj, const char *pat)
+int amm_semtype_cnst_set_textpat(amm_semtype_cnst_t *obj, const char *pat)
 {
-    CHKNULL(obj);
+    CHKERR1(obj);
+    CHKERR1(pat);
+#if defined(PCRE_FOUND)
     amm_semtype_cnst_deinit(obj);
 
     const int   opts        = PCRE2_ANCHORED | PCRE2_ENDANCHORED;
@@ -73,16 +73,17 @@ pcre2_code *amm_semtype_cnst_set_textpat(amm_semtype_cnst_t *obj, const char *pa
     if (!cfg)
     {
         CACE_LOG_ERR("Failed to compile regex pattern (error %d at %z): %s", errorcode, erroroffset, pat);
-        return NULL;
+        return 2;
     }
 
     obj->type       = AMM_SEMTYPE_CNST_TEXTPAT;
     obj->as_textpat = cfg;
 
-    return cfg;
-}
-
+    return 0;
+#else /* PCRE_FOUND */
+    return 100;
 #endif /* PCRE_FOUND */
+}
 
 cace_amm_range_int64_t *amm_semtype_cnst_set_range_int64(amm_semtype_cnst_t *obj)
 {

--- a/src/cace/amm/semtype_cnst.c
+++ b/src/cace/amm/semtype_cnst.c
@@ -80,7 +80,7 @@ int amm_semtype_cnst_set_textpat(amm_semtype_cnst_t *obj, const char *pat)
     obj->as_textpat = cfg;
 
     return 0;
-#else /* PCRE_FOUND */
+#else  /* PCRE_FOUND */
     return 100;
 #endif /* PCRE_FOUND */
 }

--- a/src/cace/amm/semtype_cnst.h
+++ b/src/cace/amm/semtype_cnst.h
@@ -65,8 +65,10 @@ typedef struct amm_semtype_cnst_s
     {
         /// Used when #type is ::AMM_SEMTYPE_CNST_STRLEN
         cace_amm_range_size_t as_strlen;
+#if defined(PCRE_FOUND)
         /// Used when #type is ::AMM_SEMTYPE_CNST_TEXTPAT
         pcre2_code *as_textpat;
+#endif /* PCRE_FOUND */
         /// Used when #type is ::AMM_SEMTYPE_CNST_RANGE_INT64
         cace_amm_range_int64_t as_range_int64;
     };

--- a/src/cace/amm/semtype_cnst.h
+++ b/src/cace/amm/semtype_cnst.h
@@ -87,8 +87,6 @@ void amm_semtype_cnst_deinit(amm_semtype_cnst_t *obj);
  */
 cace_amm_range_size_t *amm_semtype_cnst_set_strlen(amm_semtype_cnst_t *obj);
 
-#if defined(PCRE_FOUND)
-
 /** Configure a constraint on text-string regular expression pattern.
  * This applies to ARI_TYPE_TEXTSTR as well as untyped
  * primitive text strings.
@@ -100,11 +98,9 @@ cace_amm_range_size_t *amm_semtype_cnst_set_strlen(amm_semtype_cnst_t *obj);
  *
  * @param[in,out] obj The struct to set the state of.
  * @param[in] pat The regular expression to compile.
- * @return The specific parameters for this constraint type.
+ * @return Zero if successful.
  */
-pcre2_code *amm_semtype_cnst_set_textpat(amm_semtype_cnst_t *obj, const char *pat);
-
-#endif /* PCRE_FOUND */
+int amm_semtype_cnst_set_textpat(amm_semtype_cnst_t *obj, const char *pat);
 
 /** Configure a constraint on integer values based on signed 64-bit ranges.
  * This applies to ARI_TYPE_BYTE, ARI_TYPE_INT, ARI_TYPE_UINT, ARI_TYPE_VAST,

--- a/test/cace/test_amm_semtype_cnst.c
+++ b/test/cace/test_amm_semtype_cnst.c
@@ -193,11 +193,11 @@ void test_amm_semtype_cnst_textpat(const char *pat, const char *inhex, bool expe
     int res = amm_semtype_cnst_set_textpat(&cnst, pat);
 #if defined(PCRE_FOUND)
     TEST_ASSERT_EQUAL_INT(0, res);
+    check_cnst(&cnst, inhex, expect);
 #else /* PCRE_FOUND */
     TEST_ASSERT_EQUAL_INT(100, res);
 #endif /* PCRE_FOUND */
 
-    check_cnst(&cnst, inhex, expect);
     amm_semtype_cnst_deinit(&cnst);
 }
 

--- a/test/cace/test_amm_semtype_cnst.c
+++ b/test/cace/test_amm_semtype_cnst.c
@@ -171,6 +171,8 @@ void test_amm_semtype_cnst_strlen_2intvl_finite(const char *inhex, bool expect)
     amm_semtype_cnst_deinit(&cnst);
 }
 
+#if defined(PCRE_FOUND)
+
 TEST_CASE("[a-z]+", "F7", false)           // ari:undefined
 TEST_CASE("[a-z]+", "F6", false)           // ari:null
 TEST_CASE("[a-z]+", "F4", false)           // ari:false
@@ -189,6 +191,8 @@ void test_amm_semtype_cnst_textpat(const char *pat, const char *inhex, bool expe
     check_cnst(&cnst, inhex, expect);
     amm_semtype_cnst_deinit(&cnst);
 }
+
+#endif /* PCRE_FOUND */
 
 TEST_CASE("F7", false)     // ari:undefined
 TEST_CASE("F6", false)     // ari:null

--- a/test/cace/test_amm_semtype_cnst.c
+++ b/test/cace/test_amm_semtype_cnst.c
@@ -71,6 +71,7 @@ void test_amm_semtype_cnst_strlen_1intvl_finite(const char *inhex, bool expect)
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
     cace_amm_range_size_t *range = amm_semtype_cnst_set_strlen(&cnst);
+    TEST_ASSERT_NOT_NULL(range);
     {
         cace_amm_range_intvl_size_t intvl;
         cace_amm_range_intvl_size_set_finite(&intvl, 3, 5);
@@ -88,6 +89,7 @@ void test_amm_semtype_cnst_strlen_empty(const char *inhex, bool expect)
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
     cace_amm_range_size_t *range = amm_semtype_cnst_set_strlen(&cnst);
+    TEST_ASSERT_NOT_NULL(range);
 
     check_cnst(&cnst, inhex, expect);
     amm_semtype_cnst_deinit(&cnst);
@@ -101,6 +103,7 @@ void test_amm_semtype_cnst_strlen_1intvl_infinite(const char *inhex, bool expect
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
     cace_amm_range_size_t *range = amm_semtype_cnst_set_strlen(&cnst);
+    TEST_ASSERT_NOT_NULL(range);
     {
         cace_amm_range_intvl_size_t intvl;
         cace_amm_range_intvl_size_set_infinite(&intvl);
@@ -119,6 +122,7 @@ void test_amm_semtype_cnst_strlen_1intvl_lowindef(const char *inhex, bool expect
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
     cace_amm_range_size_t *range = amm_semtype_cnst_set_strlen(&cnst);
+    TEST_ASSERT_NOT_NULL(range);
     {
         cace_amm_range_intvl_size_t intvl;
         cace_amm_range_intvl_size_set_infinite(&intvl);
@@ -139,6 +143,7 @@ void test_amm_semtype_cnst_strlen_1intvl_highindef(const char *inhex, bool expec
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
     cace_amm_range_size_t *range = amm_semtype_cnst_set_strlen(&cnst);
+    TEST_ASSERT_NOT_NULL(range);
     {
         cace_amm_range_intvl_size_t intvl;
         cace_amm_range_intvl_size_set_infinite(&intvl);
@@ -159,6 +164,7 @@ void test_amm_semtype_cnst_strlen_2intvl_finite(const char *inhex, bool expect)
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
     cace_amm_range_size_t *range = amm_semtype_cnst_set_strlen(&cnst);
+    TEST_ASSERT_NOT_NULL(range);
     {
         cace_amm_range_intvl_size_t intvl;
         cace_amm_range_intvl_size_set_finite(&intvl, 0, 3);
@@ -170,8 +176,6 @@ void test_amm_semtype_cnst_strlen_2intvl_finite(const char *inhex, bool expect)
     check_cnst(&cnst, inhex, expect);
     amm_semtype_cnst_deinit(&cnst);
 }
-
-#if defined(PCRE_FOUND)
 
 TEST_CASE("[a-z]+", "F7", false)           // ari:undefined
 TEST_CASE("[a-z]+", "F6", false)           // ari:null
@@ -186,13 +190,16 @@ void test_amm_semtype_cnst_textpat(const char *pat, const char *inhex, bool expe
 {
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
-    amm_semtype_cnst_set_textpat(&cnst, pat);
+    int res = amm_semtype_cnst_set_textpat(&cnst, pat);
+#if defined(PCRE_FOUND)
+    TEST_ASSERT_EQUAL_INT(0, res);
+#else /* PCRE_FOUND */
+    TEST_ASSERT_EQUAL_INT(100, res);
+#endif /* PCRE_FOUND */
 
     check_cnst(&cnst, inhex, expect);
     amm_semtype_cnst_deinit(&cnst);
 }
-
-#endif /* PCRE_FOUND */
 
 TEST_CASE("F7", false)     // ari:undefined
 TEST_CASE("F6", false)     // ari:null
@@ -211,6 +218,7 @@ void test_amm_semtype_cnst_range_int64_1intvl_finite(const char *inhex, bool exp
     amm_semtype_cnst_t cnst;
     amm_semtype_cnst_init(&cnst);
     cace_amm_range_int64_t *range = amm_semtype_cnst_set_range_int64(&cnst);
+    TEST_ASSERT_NOT_NULL(range);
     {
         cace_amm_range_intvl_int64_t intvl;
         cace_amm_range_intvl_int64_set_finite(&intvl, -5, 5);

--- a/test/cace/test_amm_semtype_cnst.c
+++ b/test/cace/test_amm_semtype_cnst.c
@@ -194,7 +194,7 @@ void test_amm_semtype_cnst_textpat(const char *pat, const char *inhex, bool expe
 #if defined(PCRE_FOUND)
     TEST_ASSERT_EQUAL_INT(0, res);
     check_cnst(&cnst, inhex, expect);
-#else /* PCRE_FOUND */
+#else  /* PCRE_FOUND */
     TEST_ASSERT_EQUAL_INT(100, res);
 #endif /* PCRE_FOUND */
 


### PR DESCRIPTION
This avoids mostly-duplicate job definitions and makes it easier to test alternate configurations.