### PR TITLE
Issue #118 - Safely remove completed exec sequences

### DIFF
--- a/src/refda/exec.c
+++ b/src/refda/exec.c
@@ -280,7 +280,6 @@ static int refda_exec_waiting(refda_agent_t *agent)
         if (atomic_load(&(refda_exec_item_list_front(seq->items)->waiting)))
         {
             // still waiting
-            // FUTURE: is there a better way than busy waiting, especially for a long wait?
             continue;
         }
 

--- a/src/refda/exec.c
+++ b/src/refda/exec.c
@@ -293,7 +293,7 @@ static int refda_exec_waiting(refda_agent_t *agent)
            && refda_exec_item_list_empty_p(refda_exec_seq_list_front(agent->exec_state)->items))
     {
         refda_exec_seq_list_pop_front(NULL, agent->exec_state);
-        CACE_LOG_DEBUG("Remove completed item from agent exec_state queue");
+        CACE_LOG_DEBUG("Removed completed item from agent exec_state queue");
     }
 
     if (pthread_mutex_unlock(&(agent->exec_state_mutex)))


### PR DESCRIPTION
Unfortunately, when using `remove` to clean up completed sequences, sequence objects may be relocated internally via [`memmove`](https://github.com/P-p-H-d/mlib/blob/master/m-deque.h#L681), causing a disconnect between the top-level pointers and those maintained by `seq->items`. This leads to problems reported in #118 where a reference to a completed item is still held in memory, leading to the warning message.

This has been fixed by waiting until after iteration completes before popping any completed items off the front of the exec state queue. This safely removes the items while ensuring older items are removed in a timely manner.