### PR TITLE
Ensure manager ident is set for all ARI's when receiving multiple ARI's

### DIFF
--- a/src/refda/ingress.c
+++ b/src/refda/ingress.c
@@ -58,7 +58,7 @@ void *refda_ingress_worker(void *arg)
 
                 refda_msgdata_t exec_item;
                 refda_msgdata_init(&exec_item);
-                m_string_swap(exec_item.ident, meta.src);
+                m_string_init_set(exec_item.ident, meta.src);
                 cace_ari_set_move(&exec_item.value, val);
 
                 refda_msgdata_queue_push_move(agent->execs, &exec_item);


### PR DESCRIPTION
When a message is received that contains multiple ARI's, it is important that the manager's identity is preserved for all of those ARI's during execution, by copying rather than overwriting  `meta.src`. Otherwise the source name will be cleared and it will not be possible for the agent to send a reply to more than one of the ARI's.