### PR TITLE
Adding cached has_undefined state for parameters and operands

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -35,6 +35,9 @@ jobs:
     name: Unit Test (${{matrix.os}} deps=${{matrix.deps}})
     runs-on: ${{ matrix.os == 'centos-9' && 'ubuntu-24.04' || matrix.os }}
     container: ${{ matrix.os == 'centos-9' && 'quay.io/centos/centos:stream9' || null }}
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Set up OS
         if: startsWith(matrix.os, 'ubuntu')
@@ -100,9 +103,12 @@ jobs:
       matrix:
         #os: ['ubuntu-24.04', 'centos-9']
         os: ['ubuntu-24.04']
-    name: Built-Item Test (${{matrix.os}})
+    name: Built-Item Test (${{matrix.os}} gcc)
     runs-on: ${{ matrix.os == 'centos-9' && 'ubuntu-24.04' || matrix.os }}
     container: ${{ matrix.os == 'centos-9' && 'quay.io/centos/centos:stream9' || null }}
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Set up OS
         if: startsWith(matrix.os, 'ubuntu')

--- a/docs/api/Doxyfile.in
+++ b/docs/api/Doxyfile.in
@@ -32,19 +32,19 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "DTNMA Tools"
+PROJECT_NAME           = "DTNMA Reference Tools"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v@PROJECT_VERSION@
+PROJECT_NUMBER         = "v@PROJECT_VERSION@ - @GIT_TAG_MOD@"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "DTN Management Architecture Tool Suite"
+PROJECT_BRIEF          = "Delay-Tolerant Networking Management Architecture (DTNMA) Tool Suite"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/src/cace/amm/parameters.c
+++ b/src/cace/amm/parameters.c
@@ -124,7 +124,7 @@ int cace_amm_actual_param_set_populate(cace_ari_itemized_t *obj, const cace_amm_
                 if (cace_log_is_enabled_for(LOG_DEBUG))
                 {
                     cace_ari_t ariname = CACE_ARI_INIT_UNDEFINED;
-                    const bool valid = cace_amm_type_get_name(&(fparam->typeobj), &ariname);
+                    const bool valid   = cace_amm_type_get_name(&(fparam->typeobj), &ariname);
 
                     if (valid)
                     {

--- a/src/cace/amm/parameters.c
+++ b/src/cace/amm/parameters.c
@@ -81,6 +81,8 @@ int cace_amm_actual_param_set_populate(cace_ari_itemized_t *obj, const cace_amm_
     CHKERR1(gparams);
     int retval = 0;
 
+    obj->any_undefined = false;
+
     cace_amm_formal_param_list_it_t fit;
     switch (gparams->state)
     {
@@ -97,8 +99,11 @@ int cace_amm_actual_param_set_populate(cace_ari_itemized_t *obj, const cace_amm_
                 cace_ari_t *aparam = cace_ari_array_get(obj->ordered, pix);
                 cace_named_ari_ptr_dict_set_at(obj->named, string_get_cstr(fparam->name), aparam);
 
-                // FIXME don't care if it's undefined or not
                 cace_ari_set_copy(aparam, &(fparam->defval));
+                if (cace_ari_is_undefined(aparam))
+                {
+                    obj->any_undefined = true;
+                }
             }
             break;
         }
@@ -164,6 +169,11 @@ int cace_amm_actual_param_set_populate(cace_ari_itemized_t *obj, const cace_amm_
                     }
 
                     cace_ari_list_next(gparam_it);
+                }
+
+                if (cace_ari_is_undefined(aparam))
+                {
+                    obj->any_undefined = true;
                 }
             }
 
@@ -245,6 +255,11 @@ int cace_amm_actual_param_set_populate(cace_ari_itemized_t *obj, const cace_amm_
                         {
                             retval = 2;
                         }
+                    }
+
+                    if (cace_ari_is_undefined(aparam))
+                    {
+                        obj->any_undefined = true;
                     }
                 }
 

--- a/src/cace/amm/parameters.c
+++ b/src/cace/amm/parameters.c
@@ -124,13 +124,20 @@ int cace_amm_actual_param_set_populate(cace_ari_itemized_t *obj, const cace_amm_
                 if (cace_log_is_enabled_for(LOG_DEBUG))
                 {
                     cace_ari_t ariname = CACE_ARI_INIT_UNDEFINED;
-                    cace_amm_type_get_name(&(fparam->typeobj), &ariname);
+                    const bool valid = cace_amm_type_get_name(&(fparam->typeobj), &ariname);
 
-                    string_t buf;
-                    string_init(buf);
-                    cace_ari_text_encode(buf, &ariname, CACE_ARI_TEXT_ENC_OPTS_DEFAULT);
-                    CACE_LOG_DEBUG("  type %s", string_get_cstr(buf));
-                    string_clear(buf);
+                    if (valid)
+                    {
+                        string_t buf;
+                        string_init(buf);
+                        cace_ari_text_encode(buf, &ariname, CACE_ARI_TEXT_ENC_OPTS_DEFAULT);
+                        CACE_LOG_DEBUG("  type %s", string_get_cstr(buf));
+                        string_clear(buf);
+                    }
+                    else
+                    {
+                        CACE_LOG_DEBUG("  type unavailable");
+                    }
                     cace_ari_deinit(&ariname);
                 }
 

--- a/src/cace/amm/semtype.c
+++ b/src/cace/amm/semtype.c
@@ -137,24 +137,20 @@ int cace_amm_type_set_use_ref_move(cace_amm_type_t *type, cace_ari_t *name)
     return 0;
 }
 
-int cace_amm_type_set_use_direct(cace_amm_type_t *type, const cace_amm_type_t *base)
+int cace_amm_type_set_use_builtin(cace_amm_type_t *type, cace_ari_type_t ari_type)
 {
-    CHKERR1(type);
-    CHKERR1(base);
-    cace_amm_type_reset(type);
+    cace_ari_t typeref = CACE_ARI_INIT_UNDEFINED;
+    cace_ari_set_aritype_text(&typeref, ari_type);
+    int res = cace_amm_type_set_use_ref_move(type, &typeref);
+    if (res)
+    {
+        return 2;
+    }
 
-    type->match      = cace_amm_semtype_use_match;
-    type->convert    = cace_amm_semtype_use_convert;
-    type->type_class = CACE_AMM_TYPE_USE;
+    cace_amm_semtype_use_t *semtype = type->as_semtype;
+    semtype->base = cace_amm_type_get_builtin(ari_type);
 
-    cace_amm_semtype_use_t *semtype = CACE_MALLOC(sizeof(cace_amm_semtype_use_t));
-    cace_amm_semtype_use_init(semtype);
-    semtype->base = base;
-
-    type->as_semtype        = semtype;
-    type->as_semtype_deinit = (cace_amm_semtype_deinit_f)cace_amm_semtype_use_deinit;
-
-    return 0;
+    return semtype->base ? 0 : 3;
 }
 
 static void cace_amm_semtype_ulist_name(const cace_amm_type_t *self, cace_ari_t *name)

--- a/src/cace/amm/semtype.c
+++ b/src/cace/amm/semtype.c
@@ -148,7 +148,7 @@ int cace_amm_type_set_use_builtin(cace_amm_type_t *type, cace_ari_type_t ari_typ
     }
 
     cace_amm_semtype_use_t *semtype = type->as_semtype;
-    semtype->base = cace_amm_type_get_builtin(ari_type);
+    semtype->base                   = cace_amm_type_get_builtin(ari_type);
 
     return semtype->base ? 0 : 3;
 }

--- a/src/cace/amm/semtype.h
+++ b/src/cace/amm/semtype.h
@@ -81,11 +81,12 @@ int cace_amm_type_set_use_ref_move(cace_amm_type_t *type, cace_ari_t *name);
 
 /** Create a use type based on a base type object.
  * A use type adds annotations and constraints onto a base type.
+ * @warning This is intended only for internal out-of-agent testing.
  *
  * @param[out] type The type to initialize and populate.
- * @param[in] base The base type to create a use of.
+ * @param ari_type The builtin type to create a use of.
  */
-int cace_amm_type_set_use_direct(cace_amm_type_t *type, const cace_amm_type_t *base);
+int cace_amm_type_set_use_builtin(cace_amm_type_t *type, cace_ari_type_t ari_type);
 
 /// Configuration for a uniform list within an AC
 typedef struct

--- a/src/cace/ari/itemized.c
+++ b/src/cace/ari/itemized.c
@@ -23,6 +23,7 @@ void cace_ari_itemized_init(cace_ari_itemized_t *obj)
     CHKVOID(obj);
     cace_ari_array_init(obj->ordered);
     cace_named_ari_ptr_dict_init(obj->named);
+    obj->any_undefined = false;
 }
 
 void cace_ari_itemized_init_set(cace_ari_itemized_t *obj, const cace_ari_itemized_t *src)
@@ -31,6 +32,7 @@ void cace_ari_itemized_init_set(cace_ari_itemized_t *obj, const cace_ari_itemize
     CHKVOID(src);
     cace_ari_array_init_set(obj->ordered, src->ordered);
     cace_named_ari_ptr_dict_init_set(obj->named, src->named);
+    obj->any_undefined = src->any_undefined;
 }
 
 void cace_ari_itemized_init_move(cace_ari_itemized_t *obj, cace_ari_itemized_t *src)
@@ -39,6 +41,7 @@ void cace_ari_itemized_init_move(cace_ari_itemized_t *obj, cace_ari_itemized_t *
     CHKVOID(src);
     cace_ari_array_init_move(obj->ordered, src->ordered);
     cace_named_ari_ptr_dict_init_move(obj->named, src->named);
+    obj->any_undefined = src->any_undefined;
 }
 
 void cace_ari_itemized_deinit(cace_ari_itemized_t *obj)
@@ -53,4 +56,5 @@ void cace_ari_itemized_reset(cace_ari_itemized_t *obj)
     CHKVOID(obj);
     cace_ari_array_reset(obj->ordered);
     cace_named_ari_ptr_dict_reset(obj->named);
+    obj->any_undefined = false;
 }

--- a/src/cace/ari/itemized.h
+++ b/src/cace/ari/itemized.h
@@ -42,6 +42,8 @@ typedef struct
     cace_ari_array_t ordered;
     /// Lookup by (case-sensitive) text name
     cace_named_ari_ptr_dict_t named;
+    /// Indication of any item being the undefined value
+    bool any_undefined;
 } cace_ari_itemized_t;
 
 /** Initialize a new empty set.

--- a/src/refda/ctrl_exec_ctx.c
+++ b/src/refda/ctrl_exec_ctx.c
@@ -38,13 +38,21 @@ void refda_ctrl_exec_ctx_deinit(refda_ctrl_exec_ctx_t *obj)
     CHKVOID(obj);
 }
 
+bool refda_ctrl_exec_ctx_has_aparam_undefined(const refda_ctrl_exec_ctx_t *ctx)
+{
+    CHKFALSE(ctx);
+    return ctx->item->deref.aparams.any_undefined;
+}
+
 const cace_ari_t *refda_ctrl_exec_ctx_get_aparam_index(const refda_ctrl_exec_ctx_t *ctx, size_t index)
 {
+    CHKNULL(ctx);
     return cace_ari_array_cget(ctx->item->deref.aparams.ordered, index);
 }
 
 const cace_ari_t *refda_ctrl_exec_ctx_get_aparam_name(const refda_ctrl_exec_ctx_t *ctx, const char *name)
 {
+    CHKNULL(ctx);
     return *cace_named_ari_ptr_dict_cget(ctx->item->deref.aparams.named, name);
 }
 
@@ -117,6 +125,7 @@ static int refda_ctrl_exec_ctx_check_result(refda_ctrl_exec_ctx_t *ctx)
 int refda_ctrl_exec_ctx_set_result_copy(refda_ctrl_exec_ctx_t *ctx, const cace_ari_t *value)
 {
     CHKERR1(ctx);
+    CHKERR1(value);
     cace_ari_set_copy(&(ctx->item->result), value);
     return refda_ctrl_exec_ctx_check_result(ctx);
 }
@@ -124,6 +133,7 @@ int refda_ctrl_exec_ctx_set_result_copy(refda_ctrl_exec_ctx_t *ctx, const cace_a
 int refda_ctrl_exec_ctx_set_result_move(refda_ctrl_exec_ctx_t *ctx, cace_ari_t *value)
 {
     CHKERR1(ctx);
+    CHKERR1(value);
     cace_ari_set_move(&(ctx->item->result), value);
     return refda_ctrl_exec_ctx_check_result(ctx);
 }

--- a/src/refda/ctrl_exec_ctx.h
+++ b/src/refda/ctrl_exec_ctx.h
@@ -62,6 +62,13 @@ void refda_ctrl_exec_ctx_init(refda_ctrl_exec_ctx_t *obj, refda_exec_item_t *ite
 
 void refda_ctrl_exec_ctx_deinit(refda_ctrl_exec_ctx_t *obj);
 
+/** Determine if any actual parameter is undefined.
+ *
+ * @param[in] ctx The execution context.
+ * @return True if there are any undefined values.
+ */
+bool refda_ctrl_exec_ctx_has_aparam_undefined(const refda_ctrl_exec_ctx_t *ctx);
+
 /** Get an actual parameter for this execution.
  *
  * @param[in] ctx The execution context.

--- a/src/refda/edd_prod_ctx.c
+++ b/src/refda/edd_prod_ctx.c
@@ -33,13 +33,21 @@ void refda_edd_prod_ctx_deinit(refda_edd_prod_ctx_t *obj)
     CHKVOID(obj);
 }
 
+bool refda_edd_prod_ctx_has_aparam_undefined(const refda_edd_prod_ctx_t *ctx)
+{
+    CHKFALSE(ctx);
+    return ctx->prodctx->deref->aparams.any_undefined;
+}
+
 const cace_ari_t *refda_edd_prod_ctx_get_aparam_index(const refda_edd_prod_ctx_t *ctx, size_t index)
 {
+    CHKNULL(ctx);
     return cace_ari_array_cget(ctx->prodctx->deref->aparams.ordered, index);
 }
 
 const cace_ari_t *refda_edd_prod_ctx_get_aparam_name(const refda_edd_prod_ctx_t *ctx, const char *name)
 {
+    CHKNULL(ctx);
     return *cace_named_ari_ptr_dict_cget(ctx->prodctx->deref->aparams.named, name);
 }
 
@@ -66,12 +74,16 @@ static int refda_edd_prod_check_result(refda_edd_prod_ctx_t *ctx)
 
 int refda_edd_prod_ctx_set_result_move(refda_edd_prod_ctx_t *ctx, cace_ari_t *value)
 {
+    CHKERR1(ctx);
+    CHKERR1(value);
     cace_ari_set_move(&(ctx->prodctx->value), value);
     return refda_edd_prod_check_result(ctx);
 }
 
 int refda_edd_prod_ctx_set_result_copy(refda_edd_prod_ctx_t *ctx, const cace_ari_t *value)
 {
+    CHKERR1(ctx);
+    CHKERR1(value);
     cace_ari_set_copy(&(ctx->prodctx->value), value);
     return refda_edd_prod_check_result(ctx);
 }

--- a/src/refda/edd_prod_ctx.h
+++ b/src/refda/edd_prod_ctx.h
@@ -59,6 +59,13 @@ void refda_edd_prod_ctx_init(refda_edd_prod_ctx_t *obj, const refda_amm_edd_desc
 
 void refda_edd_prod_ctx_deinit(refda_edd_prod_ctx_t *obj);
 
+/** Determine if any actual parameter is undefined.
+ *
+ * @param[in] ctx The production context.
+ * @return True if there are any undefined values.
+ */
+bool refda_edd_prod_ctx_has_aparam_undefined(const refda_edd_prod_ctx_t *ctx);
+
 /** Get an actual parameter for this production.
  *
  * @param[in] ctx The production context.

--- a/src/refda/oper_eval_ctx.c
+++ b/src/refda/oper_eval_ctx.c
@@ -21,6 +21,7 @@
 
 void refda_oper_eval_ctx_init(refda_oper_eval_ctx_t *obj)
 {
+    CHKVOID(obj);
     obj->evalctx = NULL;
     obj->deref   = NULL;
     obj->oper    = NULL;
@@ -30,6 +31,7 @@ void refda_oper_eval_ctx_init(refda_oper_eval_ctx_t *obj)
 
 void refda_oper_eval_ctx_deinit(refda_oper_eval_ctx_t *obj)
 {
+    CHKVOID(obj);
     cace_ari_itemized_deinit(&(obj->operands));
     cace_ari_deinit(&(obj->result));
     obj->oper    = NULL;
@@ -41,6 +43,9 @@ int refda_oper_eval_ctx_populate(refda_oper_eval_ctx_t *obj, const cace_amm_look
                                  const refda_amm_oper_desc_t *oper, refda_eval_ctx_t *eval)
 {
     CHKERR1(obj);
+    CHKERR1(deref);
+    CHKERR1(oper);
+    CHKERR1(eval);
     obj->evalctx = eval;
     obj->deref   = deref;
     obj->oper    = oper;
@@ -81,23 +86,39 @@ int refda_oper_eval_ctx_populate(refda_oper_eval_ctx_t *obj, const cace_amm_look
     return failcnt ? 3 : 0;
 }
 
+bool refda_oper_eval_ctx_has_aparam_undefined(const refda_oper_eval_ctx_t *ctx)
+{
+    CHKFALSE(ctx);
+    return ctx->deref->aparams.any_undefined;
+}
+
 const cace_ari_t *refda_oper_eval_ctx_get_aparam_index(const refda_oper_eval_ctx_t *ctx, size_t index)
 {
+    CHKNULL(ctx);
     return cace_ari_array_cget(ctx->deref->aparams.ordered, index);
 }
 
 const cace_ari_t *refda_oper_eval_ctx_get_aparam_name(const refda_oper_eval_ctx_t *ctx, const char *name)
 {
+    CHKNULL(ctx);
     return *cace_named_ari_ptr_dict_cget(ctx->deref->aparams.named, name);
+}
+
+bool refda_oper_eval_ctx_has_operand_undefined(const refda_oper_eval_ctx_t *ctx)
+{
+    CHKFALSE(ctx);
+    return ctx->operands.any_undefined;
 }
 
 const cace_ari_t *refda_oper_eval_ctx_get_operand_index(const refda_oper_eval_ctx_t *ctx, size_t index)
 {
+    CHKNULL(ctx);
     return cace_ari_array_cget(ctx->operands.ordered, index);
 }
 
 const cace_ari_t *refda_oper_eval_ctx_get_operand_name(const refda_oper_eval_ctx_t *ctx, const char *name)
 {
+    CHKNULL(ctx);
     return *cace_named_ari_ptr_dict_cget(ctx->operands.named, name);
 }
 
@@ -108,5 +129,6 @@ void refda_oper_eval_ctx_set_result_copy(refda_oper_eval_ctx_t *ctx, const cace_
 
 void refda_oper_eval_ctx_set_result_move(refda_oper_eval_ctx_t *ctx, cace_ari_t *value)
 {
+    CHKVOID(ctx);
     cace_ari_set_move(&(ctx->result), value);
 }

--- a/src/refda/oper_eval_ctx.h
+++ b/src/refda/oper_eval_ctx.h
@@ -79,9 +79,23 @@ void refda_oper_eval_ctx_deinit(refda_oper_eval_ctx_t *obj);
 int refda_oper_eval_ctx_populate(refda_oper_eval_ctx_t *obj, const cace_amm_lookup_t *deref,
                                  const refda_amm_oper_desc_t *oper, refda_eval_ctx_t *eval);
 
+/** Determine if any actual parameter is undefined.
+ *
+ * @param[in] ctx The evaluation context.
+ * @return True if there are any undefined values.
+ */
+bool refda_oper_eval_ctx_has_aparam_undefined(const refda_oper_eval_ctx_t *ctx);
+
 const cace_ari_t *refda_oper_eval_ctx_get_aparam_index(const refda_oper_eval_ctx_t *ctx, size_t index);
 
 const cace_ari_t *refda_oper_eval_ctx_get_aparam_name(const refda_oper_eval_ctx_t *ctx, const char *name);
+
+/** Determine if any operand value is undefined.
+ *
+ * @param[in] ctx The evaluation context.
+ * @return True if there are any undefined values.
+ */
+bool refda_oper_eval_ctx_has_operand_undefined(const refda_oper_eval_ctx_t *ctx);
 
 const cace_ari_t *refda_oper_eval_ctx_get_operand_index(const refda_oper_eval_ctx_t *ctx, size_t index);
 

--- a/test/cace/test_amm_lookup.c
+++ b/test/cace/test_amm_lookup.c
@@ -52,7 +52,7 @@ void suiteSetUp(void)
         fparam->index = 0;
         string_set_str(fparam->name, "hi");
 
-        cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_INT));
     }
 
     obj = cace_amm_obj_ns_add_obj(adm, CACE_ARI_TYPE_TYPEDEF, cace_amm_idseg_ref_withenum("semtype", 0));

--- a/test/cace/test_amm_parameters.c
+++ b/test/cace/test_amm_parameters.c
@@ -113,7 +113,7 @@ TEST_CASE("8419FFFF022004", 0, true)          // ari://65535/2/-1/4
 TEST_CASE("8519FFFF02200480", 0, true)        // ari://65535/2/-1/4() special case empty params
 TEST_CASE("8519FFFF02200481F5", 0, false)     // ari://65535/2/-1/4(true)
 TEST_CASE("8519FFFF02200481626869", 0, false) // ari://65535/2/-1/4(hi) implicit cast to bool
-TEST_CASE("8519FFFF02200481F6", 0, false)      // ari://65535/2/-1/4(null) implicit cast to bool
+TEST_CASE("8519FFFF02200481F6", 0, false)     // ari://65535/2/-1/4(null) implicit cast to bool
 void test_fparam_one_bool_nodefault(const char *inhex, int expect_res, bool expect_undefined)
 {
     cace_amm_formal_param_list_t fparams;

--- a/test/cace/test_amm_parameters.c
+++ b/test/cace/test_amm_parameters.c
@@ -64,6 +64,7 @@ void test_fparam_empty(const char *inhex, int expect_res)
     cace_ari_itemized_t aparams;
     cace_ari_itemized_init(&aparams);
     check_normalize(&aparams, fparams, inhex, expect_res);
+    TEST_ASSERT_EQUAL(false, aparams.any_undefined);
 
     cace_ari_itemized_deinit(&aparams);
     cace_amm_formal_param_list_clear(fparams);
@@ -82,13 +83,14 @@ void test_fparam_one_bool(const char *inhex, int expect_res)
 
         fparam->index = 0;
         string_set_str(fparam->name, "hi");
-
         cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_BOOL));
+        cace_ari_set_bool(&(fparam->defval), false);
     }
 
     cace_ari_itemized_t aparams;
     cace_ari_itemized_init(&aparams);
     check_normalize(&aparams, fparams, inhex, expect_res);
+    TEST_ASSERT_EQUAL(false, aparams.any_undefined);
 
     cace_ari_itemized_deinit(&aparams);
     cace_amm_formal_param_list_clear(fparams);
@@ -112,13 +114,14 @@ void test_fparam_one_int(const char *inhex, int expect_res)
 
         fparam->index = 0;
         string_set_str(fparam->name, "hi");
-
         cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+        cace_ari_set_int(&(fparam->defval), 10);
     }
 
     cace_ari_itemized_t aparams;
     cace_ari_itemized_init(&aparams);
     check_normalize(&aparams, fparams, inhex, expect_res);
+    TEST_ASSERT_EQUAL(false, aparams.any_undefined);
 
     cace_ari_itemized_deinit(&aparams);
     cace_amm_formal_param_list_clear(fparams);
@@ -135,13 +138,13 @@ void test_fparam_one_object(const char *inhex, int expect_res)
 
         fparam->index = 0;
         string_set_str(fparam->name, "ref");
-
         cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_OBJECT));
     }
 
     cace_ari_itemized_t aparams;
     cace_ari_itemized_init(&aparams);
     check_normalize(&aparams, fparams, inhex, expect_res);
+    TEST_ASSERT_EQUAL(false, aparams.any_undefined);
 
     cace_ari_itemized_deinit(&aparams);
     cace_amm_formal_param_list_clear(fparams);

--- a/test/cace/test_amm_parameters.c
+++ b/test/cace/test_amm_parameters.c
@@ -19,10 +19,22 @@
 #include <cace/amm/semtype.h>
 #include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
+#include <cace/util/logging.h>
 #include <unity.h>
 
 // Allow this macro
 #define TEST_CASE(...)
+
+void suiteSetUp(void)
+{
+    cace_openlog();
+}
+
+int suiteTearDown(int failures)
+{
+    cace_closelog();
+    return failures;
+}
 
 static void check_normalize(cace_ari_itemized_t *aparams, const cace_amm_formal_param_list_t fparams, const char *inhex,
                             int expect_res)
@@ -74,6 +86,7 @@ TEST_CASE("8419FFFF022004", 0)         // ari://65535/2/-1/4
 TEST_CASE("8519FFFF02200480", 0)       // ari://65535/2/-1/4() special case empty params
 TEST_CASE("8519FFFF02200481F5", 0)     // ari://65535/2/-1/4(true)
 TEST_CASE("8519FFFF02200481626869", 0) // ari://65535/2/-1/4(hi) implicit cast to bool
+TEST_CASE("8519FFFF02200481F6", 0)     // ari://65535/2/-1/4(null) failing cast to bool
 void test_fparam_one_bool(const char *inhex, int expect_res)
 {
     cace_amm_formal_param_list_t fparams;
@@ -83,7 +96,7 @@ void test_fparam_one_bool(const char *inhex, int expect_res)
 
         fparam->index = 0;
         string_set_str(fparam->name, "hi");
-        cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_BOOL));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_BOOL));
         cace_ari_set_bool(&(fparam->defval), false);
     }
 
@@ -91,6 +104,32 @@ void test_fparam_one_bool(const char *inhex, int expect_res)
     cace_ari_itemized_init(&aparams);
     check_normalize(&aparams, fparams, inhex, expect_res);
     TEST_ASSERT_EQUAL(false, aparams.any_undefined);
+
+    cace_ari_itemized_deinit(&aparams);
+    cace_amm_formal_param_list_clear(fparams);
+}
+
+TEST_CASE("8419FFFF022004", 0, true)          // ari://65535/2/-1/4
+TEST_CASE("8519FFFF02200480", 0, true)        // ari://65535/2/-1/4() special case empty params
+TEST_CASE("8519FFFF02200481F5", 0, false)     // ari://65535/2/-1/4(true)
+TEST_CASE("8519FFFF02200481626869", 0, false) // ari://65535/2/-1/4(hi) implicit cast to bool
+TEST_CASE("8519FFFF02200481F6", 0, false)      // ari://65535/2/-1/4(null) implicit cast to bool
+void test_fparam_one_bool_nodefault(const char *inhex, int expect_res, bool expect_undefined)
+{
+    cace_amm_formal_param_list_t fparams;
+    cace_amm_formal_param_list_init(fparams);
+    {
+        cace_amm_formal_param_t *fparam = cace_amm_formal_param_list_push_back_new(fparams);
+
+        fparam->index = 0;
+        string_set_str(fparam->name, "hi");
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_BOOL));
+    }
+
+    cace_ari_itemized_t aparams;
+    cace_ari_itemized_init(&aparams);
+    check_normalize(&aparams, fparams, inhex, expect_res);
+    TEST_ASSERT_EQUAL(expect_undefined, aparams.any_undefined);
 
     cace_ari_itemized_deinit(&aparams);
     cace_amm_formal_param_list_clear(fparams);
@@ -114,7 +153,7 @@ void test_fparam_one_int(const char *inhex, int expect_res)
 
         fparam->index = 0;
         string_set_str(fparam->name, "hi");
-        cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_INT));
         cace_ari_set_int(&(fparam->defval), 10);
     }
 
@@ -138,7 +177,7 @@ void test_fparam_one_object(const char *inhex, int expect_res)
 
         fparam->index = 0;
         string_set_str(fparam->name, "ref");
-        cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_OBJECT));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_OBJECT));
     }
 
     cace_ari_itemized_t aparams;

--- a/test/cace/test_amm_typing.c
+++ b/test/cace/test_amm_typing.c
@@ -239,10 +239,8 @@ void test_amm_type_match_semtype_use_1(const char *inhex, cace_amm_type_match_re
 {
     cace_amm_type_t mytype;
     cace_amm_type_init(&mytype);
-    {
-        const cace_amm_type_t *base = cace_amm_type_get_builtin(CACE_ARI_TYPE_INT);
-        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_direct(&mytype, base));
-    }
+
+    TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&mytype, CACE_ARI_TYPE_INT));
 
     check_match(&mytype, inhex, expect);
     cace_amm_type_deinit(&mytype);
@@ -268,7 +266,7 @@ void test_amm_type_match_semtype_ulist_1(const char *inhex, cace_amm_type_match_
         cace_amm_semtype_ulist_t *semtype = cace_amm_type_set_ulist(&mytype);
         TEST_ASSERT_NOT_NULL(semtype);
 
-        cace_amm_type_set_use_direct(&(semtype->item_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(semtype->item_type), CACE_ARI_TYPE_INT));
 
         semtype->size.has_min = true;
         semtype->size.i_min   = 2;
@@ -301,12 +299,12 @@ void test_amm_type_match_semtype_dlist_2item(const char *inhex, cace_amm_type_ma
         {
             cace_amm_type_t *typ = cace_amm_type_array_get(semtype->types, 0);
             TEST_ASSERT_NOT_NULL(typ);
-            cace_amm_type_set_use_direct(typ, cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(typ, CACE_ARI_TYPE_INT));
         }
         {
             cace_amm_type_t *typ = cace_amm_type_array_get(semtype->types, 1);
             TEST_ASSERT_NOT_NULL(typ);
-            cace_amm_type_set_use_direct(typ, cace_amm_type_get_builtin(CACE_ARI_TYPE_BOOL));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(typ, CACE_ARI_TYPE_BOOL));
         }
     }
 
@@ -339,14 +337,14 @@ void test_amm_type_match_semtype_dlist_seq_minmax(const char *inhex, cace_amm_ty
         {
             cace_amm_type_t *typ = cace_amm_type_array_get(semtype->types, 0);
             TEST_ASSERT_NOT_NULL(typ);
-            cace_amm_type_set_use_direct(typ, cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(typ, CACE_ARI_TYPE_INT));
         }
         {
             cace_amm_type_t *typ = cace_amm_type_array_get(semtype->types, 1);
             TEST_ASSERT_NOT_NULL(typ);
             cace_amm_semtype_seq_t *seq = cace_amm_type_set_seq(typ);
 
-            cace_amm_type_set_use_direct(&(seq->item_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_BOOL));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(seq->item_type), CACE_ARI_TYPE_BOOL));
             seq->size.has_min = true;
             seq->size.i_min   = 1;
             seq->size.has_max = true;
@@ -377,8 +375,8 @@ void test_amm_type_match_semtype_umap_1(const char *inhex, cace_amm_type_match_r
         cace_amm_semtype_umap_t *semtype = cace_amm_type_set_umap(&mytype);
         TEST_ASSERT_NOT_NULL(semtype);
 
-        cace_amm_type_set_use_direct(&(semtype->key_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
-        cace_amm_type_set_use_direct(&(semtype->val_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_BOOL));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(semtype->key_type), CACE_ARI_TYPE_INT));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(semtype->val_type), CACE_ARI_TYPE_BOOL));
     }
 
     check_match(&mytype, inhex, expect);
@@ -401,12 +399,12 @@ void test_amm_type_match_semtype_tblt_1(const char *inhex, cace_amm_type_match_r
         {
             cace_amm_named_type_t *col = cace_amm_named_type_array_get(semtype->columns, 0);
             TEST_ASSERT_NOT_NULL(col);
-            cace_amm_type_set_use_direct(&(col->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(col->typeobj), CACE_ARI_TYPE_INT));
         }
         {
             cace_amm_named_type_t *col = cace_amm_named_type_array_get(semtype->columns, 1);
             TEST_ASSERT_NOT_NULL(col);
-            cace_amm_type_set_use_direct(&(col->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_BOOL));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(col->typeobj), CACE_ARI_TYPE_BOOL));
         }
     }
 
@@ -432,12 +430,12 @@ void test_amm_type_match_semtype_union_1(const char *inhex, cace_amm_type_match_
         {
             cace_amm_type_t *choice = cace_amm_type_array_get(semtype->choices, 0);
             TEST_ASSERT_NOT_NULL(choice);
-            cace_amm_type_set_use_direct(choice, cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(choice, CACE_ARI_TYPE_INT));
         }
         {
             cace_amm_type_t *choice = cace_amm_type_array_get(semtype->choices, 1);
             TEST_ASSERT_NOT_NULL(choice);
-            cace_amm_type_set_use_direct(choice, cace_amm_type_get_builtin(CACE_ARI_TYPE_NULL));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(choice, CACE_ARI_TYPE_NULL));
         }
     }
 

--- a/test/refda/test_amm_const.c
+++ b/test/refda/test_amm_const.c
@@ -121,7 +121,7 @@ void test_const_produce_param_one_int(const char *valhex, const char *refhex, co
         fparam->index = 0;
         string_set_str(fparam->name, "hi");
 
-        cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_INT));
     }
 
     // initial state

--- a/test/refda/test_amm_ctrl.c
+++ b/test/refda/test_amm_ctrl.c
@@ -142,7 +142,7 @@ void test_ctrl_execute_param_none(cace_ari_type_t restype, const char *refhex, c
     refda_amm_ctrl_desc_t obj;
     refda_amm_ctrl_desc_init(&obj);
     // leave formal parameter list empty
-    cace_amm_type_set_use_direct(&obj.res_type, cace_amm_type_get_builtin(restype));
+    TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&obj.res_type, restype));
     obj.execute = mock_ctrl_exec_none;
 
     cace_amm_formal_param_list_t fparams;
@@ -167,7 +167,7 @@ void test_ctrl_execute_param_one_int(const char *refhex, const char *outhex)
     refda_amm_ctrl_desc_t obj;
     refda_amm_ctrl_desc_init(&obj);
     // result is same type as parameter
-    cace_amm_type_set_use_direct(&obj.res_type, cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+    TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&obj.res_type, CACE_ARI_TYPE_INT));
     obj.execute = mock_ctrl_exec_one_int;
 
     cace_amm_formal_param_list_t fparams;
@@ -178,7 +178,7 @@ void test_ctrl_execute_param_one_int(const char *refhex, const char *outhex)
         fparam->index = 0;
         string_set_str(fparam->name, "hi");
 
-        cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+        TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_INT));
         cace_ari_set_int(&(fparam->defval), 3); // arbitrary default
     }
 

--- a/test/refda/test_eval.c
+++ b/test/refda/test_eval.c
@@ -208,7 +208,7 @@ void setUp(void)
         {
             refda_amm_var_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_var_desc_t));
             refda_amm_var_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->val_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->val_type), CACE_ARI_TYPE_VAST));
             cace_ari_set_vast(&(objdata->value), 123456);
 
             obj = refda_register_var(adm, cace_amm_idseg_ref_withenum("var1", 1), objdata);
@@ -221,13 +221,13 @@ void setUp(void)
         {
             refda_amm_edd_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_edd_desc_t));
             refda_amm_edd_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->prod_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->prod_type), CACE_ARI_TYPE_VAST));
             objdata->produce = test_reporting_edd_one_int;
 
             obj = refda_register_edd(adm, cace_amm_idseg_ref_withenum("edd2", 2), objdata);
             {
                 cace_amm_formal_param_t *fparam = refda_register_add_param(obj, "val");
-                cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+                TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_VAST));
             }
         }
 
@@ -242,21 +242,21 @@ void setUp(void)
             {
                 cace_amm_named_type_t *operand = cace_amm_named_type_array_get(objdata->operand_types, 0);
                 string_set_str(operand->name, "left");
-                cace_amm_type_set_use_direct(&(operand->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+                TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(operand->typeobj), CACE_ARI_TYPE_VAST));
             }
             {
                 cace_amm_named_type_t *operand = cace_amm_named_type_array_get(objdata->operand_types, 1);
                 string_set_str(operand->name, "right");
-                cace_amm_type_set_use_direct(&(operand->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+                TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(operand->typeobj), CACE_ARI_TYPE_VAST));
             }
-            cace_amm_type_set_use_direct(&(objdata->res_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->res_type), CACE_ARI_TYPE_VAST));
 
             objdata->evaluate = test_reporting_oper_add;
 
             obj = refda_register_oper(adm, cace_amm_idseg_ref_withenum("oper1", 1), objdata);
             {
                 cace_amm_formal_param_t *fparam = refda_register_add_param(obj, "more");
-                cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+                TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_VAST));
             }
         }
     }

--- a/test/refda/test_exec.c
+++ b/test/refda/test_exec.c
@@ -141,13 +141,13 @@ void setUp(void)
         {
             refda_amm_edd_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_edd_desc_t));
             refda_amm_edd_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->prod_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->prod_type), CACE_ARI_TYPE_VAST));
             objdata->produce = test_reporting_edd_one_int;
 
             obj = refda_register_edd(adm, cace_amm_idseg_ref_withenum("edd2", 2), objdata);
             {
                 cace_amm_formal_param_t *fparam = refda_register_add_param(obj, "val");
-                cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+                TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_VAST));
             }
         }
 
@@ -157,27 +157,27 @@ void setUp(void)
         {
             refda_amm_ctrl_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_ctrl_desc_t));
             refda_amm_ctrl_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->res_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->res_type), CACE_ARI_TYPE_VAST));
             objdata->execute = test_exec_ctrl_exec_one_int;
 
             obj = refda_register_ctrl(adm, cace_amm_idseg_ref_withenum("ctrl1", 1), objdata);
             {
                 cace_amm_formal_param_t *fparam = refda_register_add_param(obj, "one");
 
-                cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+                TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_INT));
             }
         }
         {
             refda_amm_ctrl_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_ctrl_desc_t));
             refda_amm_ctrl_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->res_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->res_type), CACE_ARI_TYPE_VAST));
             objdata->execute = test_exec_ctrl_exec_one_int;
 
             obj = refda_register_ctrl(adm, cace_amm_idseg_ref_withenum("ctrl2", 2), objdata);
             {
                 cace_amm_formal_param_t *fparam = refda_register_add_param(obj, "one");
 
-                cace_amm_type_set_use_direct(&(fparam->typeobj), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+                TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(fparam->typeobj), CACE_ARI_TYPE_INT));
             }
         }
     }

--- a/test/refda/test_reporting.c
+++ b/test/refda/test_reporting.c
@@ -132,7 +132,7 @@ void setUp(void)
         {
             refda_amm_var_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_var_desc_t));
             refda_amm_var_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->val_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_VAST));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->val_type), CACE_ARI_TYPE_VAST));
             cace_ari_set_vast(&(objdata->value), 123456);
 
             obj = refda_register_var(adm, cace_amm_idseg_ref_withenum("var1", 1), objdata);
@@ -145,7 +145,7 @@ void setUp(void)
         {
             refda_amm_edd_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_edd_desc_t));
             refda_amm_edd_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->prod_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->prod_type), CACE_ARI_TYPE_INT));
             objdata->produce = test_reporting_edd_int;
 
             obj = refda_register_edd(adm, cace_amm_idseg_ref_withenum("edd1", 1), objdata);
@@ -154,7 +154,7 @@ void setUp(void)
         {
             refda_amm_edd_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_edd_desc_t));
             refda_amm_edd_desc_init(objdata);
-            cace_amm_type_set_use_direct(&(objdata->prod_type), cace_amm_type_get_builtin(CACE_ARI_TYPE_INT));
+            TEST_ASSERT_EQUAL_INT(0, cace_amm_type_set_use_builtin(&(objdata->prod_type), CACE_ARI_TYPE_INT));
             objdata->produce = test_reporting_edd_one_int;
 
             obj = refda_register_edd(adm, cace_amm_idseg_ref_withenum("edd2", 2), objdata);


### PR DESCRIPTION
This allows callbacks a simple constant-time precondition check.