### PR TITLE
make refda more modular #188

### DIFF
--- a/src/refda/agent.c
+++ b/src/refda/agent.c
@@ -282,20 +282,30 @@ int refda_agent_init_objs(refda_agent_t *agent)
 int refda_agent_start(refda_agent_t *agent)
 {
     CHKERR1(agent);
-    CHKERR1(agent->mif.recv);
-    CHKERR1(agent->mif.send);
     CACE_LOG_INFO("Work threads starting...");
 
-    // clang-format off
-    cace_threadinfo_t threadinfo[] = {
-        { &refda_ingress_worker, "ingress" },
-        { &refda_egress_worker, "egress" },
-        { &refda_exec_worker, "exec" },
-        //        { &rda_reports, "rda_reports" },
-        //        { &rda_rules, "rda_rules" },
-    };
-    // clang-format on
-    int res = cace_threadset_start(agent->threads, threadinfo, sizeof(threadinfo) / sizeof(cace_threadinfo_t), agent);
+    /**
+     * This following code only runs the ingress or egress threads if mif.recv and/or mif.send are defined.
+     * This allows for short-cutting the ingress or egress threads and workers such that you can directly push into or
+     * pop from the inter-thread queues. This is fully implemented for overwriting the ingress system using a call to
+     * refda_ingress_push_move from a "external" thread.
+     */
+    size_t       threadCount = 0;
+    cace_threadinfo_t threadinfo[3];
+    if (agent->mif.recv)
+    {
+        threadinfo[threadCount].func   = &refda_ingress_worker;
+        threadinfo[threadCount++].name = "ingress";
+    }
+    if (agent->mif.send)
+    {
+        threadinfo[threadCount].func   = &refda_egress_worker;
+        threadinfo[threadCount++].name = "egress";
+    }
+    threadinfo[threadCount].func   = &refda_exec_worker;
+    threadinfo[threadCount++].name = "exec";
+
+    int res = cace_threadset_start(agent->threads, threadinfo, threadCount, agent);
     if (res)
     {
         CACE_LOG_ERR("Failed to start work threads: %d", res);
@@ -310,6 +320,17 @@ int refda_agent_stop(refda_agent_t *agent)
 {
     CHKERR1(agent);
     CACE_LOG_INFO("Work threads stopping...");
+
+    // If the ingress system has been overwritten, then the undefined message needs to be
+    // pushed in to signal shutdown.
+    if (agent->mif.recv == NULL)
+    {
+        // Send sentinel to end thread execution
+        refda_msgdata_t undef;
+        refda_msgdata_init(&undef);
+        refda_msgdata_queue_push_move(&agent->execs[0], &undef);
+        sem_post(&(agent->execs_sem));
+    }
 
     /* Notify threads */
     cace_daemon_run_stop(&agent->running);

--- a/src/refda/ingress.h
+++ b/src/refda/ingress.h
@@ -19,6 +19,8 @@
 #ifndef REFDA_INGRESS_H_
 #define REFDA_INGRESS_H_
 
+#include "agent.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,6 +31,17 @@ extern "C" {
  * @return Always NULL pointer.
  */
 void *refda_ingress_worker(void *arg);
+
+/**
+ * API for external thread to push ARIs into exec thread. This can be used instead of
+ * the refda_ingress_worker. To do this, set the agent's `mif.recv` to NULL to prevent
+ * starting the ingress thread.
+ *
+ * @param agent a pointer to the agent
+ * @param meta structure containing the manager's id
+ * @param ari the ARI to insert
+ */
+void refda_ingress_push_move(refda_agent_t *agent, const cace_amm_msg_if_metadata_t *meta, cace_ari_t *ari);
 
 #ifdef __cplusplus
 } // extern C


### PR DESCRIPTION
Allows you to shortcut ingress or egress queues if wished. See `refda_ingress_push_move()`, `refda_agent_start()`, and `refda_agent_stop()`.