### PR TITLE
Avoid memory leak in cace_amp_proxy_cli_send

### DIFF
--- a/src/cace/amp/proxy_cli.c
+++ b/src/cace/amp/proxy_cli.c
@@ -179,7 +179,6 @@ int cace_amp_proxy_cli_send(const cace_ari_list_t data, const cace_amm_msg_if_me
 
         int     flags = 0;
         ssize_t got   = send(sock_fd, msg_begin, msg_size, flags);
-        m_bstring_clear(msgbuf);
 
         if (got != (ssize_t)msg_size)
         {
@@ -188,6 +187,7 @@ int cace_amp_proxy_cli_send(const cace_ari_list_t data, const cace_amm_msg_if_me
             result = 4;
         }
     }
+    m_bstring_clear(msgbuf);
 
     return result;
 }


### PR DESCRIPTION
Ensure `m_bstring_clear` is called in all cases to free allocated memory.