### PR TITLE
Update clang-format configuration and resulting auto format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,6 +53,7 @@ IndentCaseLabels: true
 IndentExternBlock: NoIndent
 IndentPPDirectives: None
 IndentWidth:     4
+InsertBraces: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''

--- a/src/cace/amm/numeric.c
+++ b/src/cace/amm/numeric.c
@@ -207,7 +207,9 @@ int cace_numeric_binary_operator(cace_ari_t *result, const cace_ari_t *lt_val, c
     is_oper_TS |= lt_typ == CACE_ARI_TYPE_TD || lt_typ == CACE_ARI_TYPE_TP;
     is_oper_TS |= rt_typ == CACE_ARI_TYPE_TD || rt_typ == CACE_ARI_TYPE_TP;
     if (is_oper_TS == true)
+    {
         return op_timespec(result, lt_val, rt_val);
+    }
 
     // Logic for non timespec operations
     cace_ari_type_t promote;

--- a/src/refdm/nm_sql.c
+++ b/src/refdm/nm_sql.c
@@ -929,13 +929,17 @@ static void debugPostgresSqlResult(PGresult *res, int max_row_cnt)
     int num_cols = PQnfields(res);
     fprintf(stderr, "...Number of rows: %d   |   Number of cols: %d\n", num_rows, num_cols);
     if (max_row_cnt > 0 && max_row_cnt < num_rows)
+    {
         fprintf(stderr, "...Max rows to log: %d\n", max_row_cnt);
+    }
 
     // Iterate through each row and send the table column and log contents
     for (int row = 0; row < num_rows; row++)
     {
         if (row == max_row_cnt)
+        {
             break;
+        }
 
         fprintf(stderr, "......Row %d:\n", row);
         for (int col = 0; col < num_cols; col++)


### PR DESCRIPTION
Branch for demoing the updated clang-format option.

Note the following:
- Requirement for clang-format version >= 15.
- The warning about setting this to true can lead to incorrect formatting

Source:
   [https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertbraces](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertbraces)