### PR TITLE
Avoid deprecated structures to help M*LIB compatibility

### DIFF
--- a/src/cace/ari/access.c
+++ b/src/cace/ari/access.c
@@ -564,7 +564,7 @@ void cace_ari_set_ac(cace_ari_t *ari, struct cace_ari_ac_s *src)
     CHKVOID(ari);
     cace_ari_deinit(ari);
 
-    cace_ari_ac_t *ctr = M_MEMORY_ALLOC(cace_ari_ac_t);
+    cace_ari_ac_t *ctr = CACE_MALLOC(sizeof(cace_ari_ac_t));
     cace_ari_ac_init(ctr);
     if (src)
     {
@@ -602,7 +602,7 @@ void cace_ari_set_am(cace_ari_t *ari, struct cace_ari_am_s *src)
     CHKVOID(ari);
     cace_ari_deinit(ari);
 
-    cace_ari_am_t *ctr = M_MEMORY_ALLOC(cace_ari_am_t);
+    cace_ari_am_t *ctr = CACE_MALLOC(sizeof(cace_ari_am_t));
     cace_ari_am_init(ctr);
     if (src)
     {
@@ -640,7 +640,7 @@ void cace_ari_set_tbl(cace_ari_t *ari, struct cace_ari_tbl_s *src)
     CHKVOID(ari);
     cace_ari_deinit(ari);
 
-    cace_ari_tbl_t *ctr = M_MEMORY_ALLOC(cace_ari_tbl_t);
+    cace_ari_tbl_t *ctr = CACE_MALLOC(sizeof(cace_ari_tbl_t));
     cace_ari_tbl_init(ctr, 0, 0);
     if (src)
     {

--- a/src/cace/ari/containers.c
+++ b/src/cace/ari/containers.c
@@ -389,35 +389,35 @@ void cace_ari_lit_init_container(cace_ari_lit_t *lit, cace_ari_type_t ctype)
     {
         case CACE_ARI_TYPE_AC:
         {
-            cace_ari_ac_t *ctr = M_MEMORY_ALLOC(cace_ari_ac_t);
+            cace_ari_ac_t *ctr = CACE_MALLOC(sizeof(cace_ari_ac_t));
             cace_ari_ac_init(ctr);
             lit->value.as_ac = ctr;
             break;
         }
         case CACE_ARI_TYPE_AM:
         {
-            cace_ari_am_t *ctr = M_MEMORY_ALLOC(cace_ari_am_t);
+            cace_ari_am_t *ctr = CACE_MALLOC(sizeof(cace_ari_am_t));
             cace_ari_am_init(ctr);
             lit->value.as_am = ctr;
             break;
         }
         case CACE_ARI_TYPE_TBL:
         {
-            cace_ari_tbl_t *ctr = M_MEMORY_ALLOC(cace_ari_tbl_t);
+            cace_ari_tbl_t *ctr = CACE_MALLOC(sizeof(cace_ari_tbl_t));
             cace_ari_tbl_init(ctr, 0, 0);
             lit->value.as_tbl = ctr;
             break;
         }
         case CACE_ARI_TYPE_EXECSET:
         {
-            cace_ari_execset_t *ctr = M_MEMORY_ALLOC(cace_ari_execset_t);
+            cace_ari_execset_t *ctr = CACE_MALLOC(sizeof(cace_ari_execset_t));
             cace_ari_execset_init(ctr);
             lit->value.as_execset = ctr;
             break;
         }
         case CACE_ARI_TYPE_RPTSET:
         {
-            cace_ari_rptset_t *ctr = M_MEMORY_ALLOC(cace_ari_rptset_t);
+            cace_ari_rptset_t *ctr = CACE_MALLOC(sizeof(cace_ari_rptset_t));
             cace_ari_rptset_init(ctr);
             lit->value.as_rptset = ctr;
             break;

--- a/src/cace/ari/lit.c
+++ b/src/cace/ari/lit.c
@@ -50,27 +50,27 @@ int cace_ari_lit_deinit(cace_ari_lit_t *obj)
             case CACE_ARI_TYPE_AC:
                 CHKERR1(obj->value.as_ac);
                 cace_ari_ac_deinit(obj->value.as_ac);
-                M_MEMORY_DEL(obj->value.as_ac);
+                CACE_FREE(obj->value.as_ac);
                 break;
             case CACE_ARI_TYPE_AM:
                 CHKERR1(obj->value.as_am);
                 cace_ari_am_deinit(obj->value.as_am);
-                M_MEMORY_DEL(obj->value.as_am);
+                CACE_FREE(obj->value.as_am);
                 break;
             case CACE_ARI_TYPE_TBL:
                 CHKERR1(obj->value.as_tbl);
                 cace_ari_tbl_deinit(obj->value.as_tbl);
-                M_MEMORY_DEL(obj->value.as_tbl);
+                CACE_FREE(obj->value.as_tbl);
                 break;
             case CACE_ARI_TYPE_EXECSET:
                 CHKERR1(obj->value.as_execset);
                 cace_ari_execset_deinit(obj->value.as_execset);
-                M_MEMORY_DEL(obj->value.as_execset);
+                CACE_FREE(obj->value.as_execset);
                 break;
             case CACE_ARI_TYPE_RPTSET:
                 CHKERR1(obj->value.as_rptset);
                 cace_ari_rptset_deinit(obj->value.as_rptset);
-                M_MEMORY_DEL(obj->value.as_rptset);
+                CACE_FREE(obj->value.as_rptset);
                 break;
             default:
                 // do nothing

--- a/src/cace/ari/text_str.yac
+++ b/src/cace/ari/text_str.yac
@@ -115,7 +115,7 @@ void cace_ari_text_str_error(yyscan_t *scanner, cace_ari_text_str_t *input, char
 %destructor { string_clear($$); } <text>
 %destructor { cace_named_ari_dict_clear($$); } <litparams>
 %destructor { cace_ari_lit_deinit(&$$); } <lit>
-%destructor { if ($$) { cace_ari_report_deinit($$); M_MEMORY_DEL($$); } } <report>
+%destructor { if ($$) { cace_ari_report_deinit($$); CACE_FREE($$); } } <report>
 %destructor { cace_ari_ref_deinit(&$$); } <objref>
 %destructor { cace_ari_objpath_deinit(&$$); } <objpath>
 %destructor { cace_ari_idseg_deinit(&$$); } <idseg>
@@ -648,7 +648,7 @@ int cace_ari_lit_from_text(yyscan_t *scanner, cace_ari_text_str_t *input, cace_a
         cace_ari_text_str_error(scanner, input, "%s", errm);
         if (errm)
         {
-            M_MEMORY_FREE((char *)errm);
+            CACE_FREE((char *)errm);
         }
         return 1;
     }

--- a/src/refda/exec.c
+++ b/src/refda/exec.c
@@ -262,7 +262,7 @@ static int refda_exec_exp_item(refda_runctx_t *runctx, refda_exec_seq_t *seq, co
     return retval;
 }
 
-int refda_exec_exp_target(refda_exec_seq_t *seq, refda_runctx_ptr_t runctxp, const cace_ari_t *target)
+int refda_exec_exp_target(refda_exec_seq_t *seq, refda_runctx_ptr_t *runctxp, const cace_ari_t *target)
 {
     CHKERR1(target);
     refda_runctx_t *runctx = refda_runctx_ptr_ref(runctxp);
@@ -283,7 +283,7 @@ int refda_exec_exp_target(refda_exec_seq_t *seq, refda_runctx_ptr_t runctxp, con
         string_clear(buf);
     }
 
-    refda_runctx_ptr_set(seq->runctx, runctxp);
+    refda_runctx_ptr_set(&seq->runctx, runctxp);
 
     cace_ari_array_t invalid_items;
     cace_ari_array_init(invalid_items);
@@ -382,8 +382,7 @@ static int refda_exec_exp_execset(refda_agent_t *agent, const refda_msgdata_t *m
     CHKERR1(agent);
     CHKERR1(msg);
 
-    refda_runctx_ptr_t ctxptr;
-    refda_runctx_ptr_init_new(ctxptr);
+    refda_runctx_ptr_t *ctxptr = refda_runctx_ptr_new();
 
     if (refda_runctx_from(refda_runctx_ptr_ref(ctxptr), agent, msg))
     {
@@ -554,8 +553,7 @@ static int refda_exec_schedule_tbr(refda_agent_t *agent, refda_amm_tbr_desc_t *t
  */
 static int refda_exec_rule_action(refda_agent_t *agent, refda_exec_seq_t *seq, const cace_ari_t *action)
 {
-    refda_runctx_ptr_t ctxptr;
-    refda_runctx_ptr_init_new(ctxptr);
+    refda_runctx_ptr_t *ctxptr = refda_runctx_ptr_new();
 
     refda_runctx_t *runctx = refda_runctx_ptr_ref(ctxptr);
 
@@ -564,7 +562,7 @@ static int refda_exec_rule_action(refda_agent_t *agent, refda_exec_seq_t *seq, c
         return 2;
     }
 
-    refda_runctx_ptr_set(seq->runctx, ctxptr);
+    refda_runctx_ptr_set(&seq->runctx, ctxptr);
 
     cace_ari_array_t invalid_items;
     cace_ari_array_init(invalid_items);

--- a/src/refda/exec.h
+++ b/src/refda/exec.h
@@ -43,7 +43,7 @@ extern "C" {
  * @param[in] ari The ARI to dereference, if necessary, and execute.
  * @return Zero if successful.
  */
-int refda_exec_exp_target(refda_exec_seq_t *seq, refda_runctx_ptr_t runctxp, const cace_ari_t *ari);
+int refda_exec_exp_target(refda_exec_seq_t *seq, refda_runctx_ptr_t *runctxp, const cace_ari_t *ari);
 
 /** Implement the running procedure from Section TBD of @cite ietf-dtn-amm-01.
  * This executes items in a sequence until the first deferred completion.

--- a/src/refda/exec_seq.c
+++ b/src/refda/exec_seq.c
@@ -21,7 +21,7 @@
 void refda_exec_seq_init(refda_exec_seq_t *obj)
 {
     CHKVOID(obj);
-    refda_runctx_ptr_init(obj->runctx);
+    obj->runctx = refda_runctx_ptr_new();
     obj->pid = 0;
     refda_exec_item_list_init(obj->items);
 }

--- a/src/refda/exec_seq.h
+++ b/src/refda/exec_seq.h
@@ -37,7 +37,7 @@ DEQUE_DEF(refda_exec_item_list, refda_exec_item_t)
 typedef struct refda_exec_seq_s
 {
     /// Context for the source of this sequence
-    refda_runctx_ptr_t runctx;
+    refda_runctx_ptr_t *runctx;
 
     /** Internal unique processing identifier for the execution.
      * Zero is an invalid value and will not be assigned.

--- a/src/refda/runctx.h
+++ b/src/refda/runctx.h
@@ -20,7 +20,7 @@
 
 #include "cace/ari/base.h"
 #include "cace/amm/lookup.h"
-#include <m-shared.h>
+#include <m-shared-ptr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/refda/test_adm_ietf_dtnma_agent.c
+++ b/test/refda/test_adm_ietf_dtnma_agent.c
@@ -85,8 +85,7 @@ void tearDown(void)
 
 static void check_execute(const cace_ari_t *target)
 {
-    refda_runctx_ptr_t ctxptr;
-    refda_runctx_ptr_init_new(ctxptr);
+    refda_runctx_ptr_t *ctxptr = refda_runctx_ptr_new();
     // no nonce for test
     refda_runctx_from(refda_runctx_ptr_ref(ctxptr), &agent, NULL);
 

--- a/test/refda/test_amm_ctrl.c
+++ b/test/refda/test_amm_ctrl.c
@@ -75,14 +75,13 @@ static void check_execute(cace_ari_t *result, const refda_amm_ctrl_desc_t *ctrl,
     cace_amm_obj_desc_init(&obj);
     cace_amm_user_data_set_from(&(obj.app_data), (void *)ctrl, false, NULL);
 
-    refda_runctx_ptr_t ctxptr;
-    refda_runctx_ptr_init_new(ctxptr);
+    refda_runctx_ptr_t *ctxptr = refda_runctx_ptr_new();
     // no nonce for test
     refda_runctx_from(refda_runctx_ptr_ref(ctxptr), NULL, NULL);
 
     refda_exec_seq_t eseq;
     refda_exec_seq_init(&eseq);
-    refda_runctx_ptr_set(eseq.runctx, ctxptr);
+    refda_runctx_ptr_set(&eseq.runctx, ctxptr);
 
     refda_exec_item_t eitem;
     refda_exec_item_init(&eitem);

--- a/test/refda/test_exec.c
+++ b/test/refda/test_exec.c
@@ -233,8 +233,7 @@ static void check_execute(const cace_ari_t *target, int expect_exp, int wait_lim
         string_clear(buf);
     }
 
-    refda_runctx_ptr_t ctxptr;
-    refda_runctx_ptr_init_new(ctxptr);
+    refda_runctx_ptr_t *ctxptr = refda_runctx_ptr_new();
     // no nonce for test
     refda_runctx_from(refda_runctx_ptr_ref(ctxptr), &agent, NULL);
 


### PR DESCRIPTION
This also bumps M*LIB submodule to a release version tag.