### PR TITLE
Relocate internal tbl-filter code for CAMP

### DIFF
--- a/src/refda/adm/ietf_dtnma_agent.c
+++ b/src/refda/adm/ietf_dtnma_agent.c
@@ -636,6 +636,87 @@ static int timespec_numeric_mod(cace_ari_t *result _U_, const cace_ari_t *left _
     return RET_FAIL_UNDEFINED;
 }
 
+typedef struct
+{
+    cace_ari_tbl_t *tbl;
+    int             row_index;
+} _tbl_row_pair_t;
+
+/**
+ * Translation helper function to substitute any LABELS in the expression with
+ * corresponding data from the current table row.
+ *
+ * Assumes the LABEL contains an index of the column which will substitute data
+ */
+static int tbl_filter_sub_label(cace_ari_lit_t *out, const cace_ari_lit_t *in, const cace_ari_translate_ctx_t *ctx)
+{
+    int              res;
+    _tbl_row_pair_t *table_data = (_tbl_row_pair_t *)ctx->user_data;
+
+    if (in->has_ari_type && in->ari_type == CACE_ARI_TYPE_LABEL)
+    {
+        cace_ari_tbl_t *tbl_data  = table_data->tbl;
+        int             row_index = table_data->row_index;
+        int             label_id  = 0;
+
+        // Get label ID value
+        switch (in->prim_type)
+        {
+            case CACE_ARI_PRIM_UINT64:
+            {
+                const uint64_t *val = &(in->value.as_uint64);
+                if (*val > INT32_MAX)
+                {
+                    return 3;
+                }
+                label_id = *val;
+                break;
+            }
+            case CACE_ARI_PRIM_INT64:
+            {
+                const int64_t *val = &(in->value.as_int64);
+                if ((*val < INT32_MIN) || (*val > INT32_MAX))
+                {
+                    return 3;
+                }
+                label_id = *val;
+                break;
+            }
+            default:
+                return 2;
+        }
+
+        // Get column index
+        int col_index = label_id;
+        if (col_index >= (int)tbl_data->ncols)
+        {
+            CACE_LOG_WARNING("Invalid colum index %d, skipping", col_index);
+            return 1;
+        }
+
+        // Get data value from table
+        size_t      array_index   = (row_index * tbl_data->ncols) + col_index;
+        cace_ari_t *tbl_data_item = cace_ari_array_get(tbl_data->items, array_index);
+
+        // Replace label with table data
+        if (tbl_data_item->is_ref)
+        {
+            CACE_LOG_WARNING("Substitution of lit with ref currently not supported");
+            res = cace_ari_lit_copy(out, in);
+        }
+        else
+        {
+            res = cace_ari_lit_copy(out, &(tbl_data_item->as_lit));
+        }
+    }
+    else
+    {
+        res = cace_ari_lit_copy(out, in);
+    }
+
+    return res;
+}
+
 /*   STOP CUSTOM FUNCTIONS HERE  */
 
 /* Name: sw-vendor
@@ -4162,87 +4243,6 @@ static void refda_adm_ietf_dtnma_agent_oper_compare_le(refda_oper_eval_ctx_t *ct
      * |STOP CUSTOM FUNCTION refda_adm_ietf_dtnma_agent_oper_compare_le BODY
      * +-------------------------------------------------------------------------+
      */
-}
-
-typedef struct
-{
-    cace_ari_tbl_t *tbl;
-    int             row_index;
-} _tbl_row_pair_t;
-
-/**
- * Translation helper function to substitute any LABELS in the expression with
- * corresponding data from the current table row.
- *
- * Assumes the LABEL contains an index of the column which will substitute data
- */
-static int tbl_filter_sub_label(cace_ari_lit_t *out, const cace_ari_lit_t *in, const cace_ari_translate_ctx_t *ctx)
-{
-    int              res;
-    _tbl_row_pair_t *table_data = (_tbl_row_pair_t *)ctx->user_data;
-
-    if (in->has_ari_type && in->ari_type == CACE_ARI_TYPE_LABEL)
-    {
-        cace_ari_tbl_t *tbl_data  = table_data->tbl;
-        int             row_index = table_data->row_index;
-        int             label_id  = 0;
-
-        // Get label ID value
-        switch (in->prim_type)
-        {
-            case CACE_ARI_PRIM_UINT64:
-            {
-                const uint64_t *val = &(in->value.as_uint64);
-                if (*val > INT32_MAX)
-                {
-                    return 3;
-                }
-                label_id = *val;
-                break;
-            }
-            case CACE_ARI_PRIM_INT64:
-            {
-                const int64_t *val = &(in->value.as_int64);
-                if ((*val < INT32_MIN) || (*val > INT32_MAX))
-                {
-                    return 3;
-                }
-                label_id = *val;
-                break;
-            }
-            default:
-                return 2;
-        }
-
-        // Get column index
-        int col_index = label_id;
-        if (col_index >= (int)tbl_data->ncols)
-        {
-            CACE_LOG_WARNING("Invalid colum index %d, skipping", col_index);
-            return 1;
-        }
-
-        // Get data value from table
-        size_t      array_index   = (row_index * tbl_data->ncols) + col_index;
-        cace_ari_t *tbl_data_item = cace_ari_array_get(tbl_data->items, array_index);
-
-        // Replace label with table data
-        if (tbl_data_item->is_ref)
-        {
-            CACE_LOG_WARNING("Substitution of lit with ref currently not supported");
-            res = cace_ari_lit_copy(out, in);
-        }
-        else
-        {
-            res = cace_ari_lit_copy(out, &(tbl_data_item->as_lit));
-        }
-    }
-    else
-    {
-        res = cace_ari_lit_copy(out, in);
-    }
-
-    return res;
 }
 
 /* Name: tbl-filter


### PR DESCRIPTION
Move internal `tbl-filter` code so it is preserved by the CAMP tool when ADM is regenerated.