### PR TITLE
Fix ACL filters in startup macros for integration tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -229,6 +229,9 @@ jobs:
         run: ./integration-test-${{matrix.transport}}/run.sh start
       - name: Test
         run: ./integration-test-${{matrix.transport}}/run.sh check
+      - name: Logs
+        if: always()
+        run: ./integration-test-${{matrix.transport}}/run.sh logs
       - name: Stop
         if: always()
         run: ./integration-test-${{matrix.transport}}/run.sh stop

--- a/integration-test-ion/run.sh
+++ b/integration-test-ion/run.sh
@@ -23,6 +23,9 @@ cd "${SELFDIR}"
 
 DOCKER=${DOCKER:-docker}
 
+DEXEC="${DOCKER} compose exec -T -e REFDA_EID=ipn:2.6 manager"
+AEXEC="${DOCKER} compose exec -T agent1"
+
 if [ "$1" = "start" ]
 then
     export DOCKER_BUILDKIT=1
@@ -33,12 +36,18 @@ elif [ "$1" = "stop" ]
 then
     ${DOCKER} compose down --rmi local --volumes
     ${DOCKER} compose rm --force --volumes
+elif [ "$1" = "logs" ]
+then
+    echo "Manager log..."
+    ${DEXEC} journalctl --unit refdm-ion
+    echo
+
+    echo "Agent log..."
+    ${AEXEC} journalctl --unit refda-ion
+    echo
 elif [ "$1" = "check" ]
 then
     ${DOCKER} compose ps
-
-    DEXEC="${DOCKER} compose exec -T -e REFDA_EID=ipn:2.6 manager"
-    AEXEC="${DOCKER} compose exec -T agent1"
 
     # Wait for necessary daemons to start
     for IX in $(seq 10)

--- a/integration-test-ion/startup.uri
+++ b/integration-test-ion/startup.uri
@@ -1,3 +1,3 @@
 //ietf/dtnma-agent-acl/ctrl/ensure-group(1,test-agents)
-//ietf/dtnma-agent-acl/ctrl/ensure-group-members(1,/ac/(//ietf/network-base/ident/uri-regexp-pattern(%22ipn%3A.%2A%22)))
+//ietf/dtnma-agent-acl/ctrl/ensure-group-members(1,/ac/(/label/0,//ietf/dtnma-agent/oper/match-regexp(%22ipn%3A.%2A%22)))
 //ietf/dtnma-agent-acl/CTRL/ensure-access(1,/ac/(1),/ac/(/objpat/(*)(*)(*)(*)),/ac/(//ietf/dtnma-agent-acl/ident/execute,//ietf/dtnma-agent-acl/ident/produce))

--- a/integration-test-proxy/run.sh
+++ b/integration-test-proxy/run.sh
@@ -23,6 +23,10 @@ cd "${SELFDIR}"
 
 DOCKER=${DOCKER:-docker}
 
+DEXEC="${DOCKER} compose exec -T -e REFDA_EID=ipn:2.6 amp-manager"
+MEXEC="${DOCKER} compose exec -T ion-manager"
+AEXEC="${DOCKER} compose exec -T agent1"
+
 if [ "$1" = "start" ]
 then
     export DOCKER_BUILDKIT=1
@@ -33,13 +37,18 @@ elif [ "$1" = "stop" ]
 then
     ${DOCKER} compose down --rmi local --volumes
     ${DOCKER} compose rm --force --volumes
+elif [ "$1" = "logs" ]
+then
+    echo "Manager log..."
+    ${MEXEC} journalctl --unit refdm-proxy
+    echo
+
+    echo "Agent log..."
+    ${AEXEC} journalctl --unit refda-ion
+    echo
 elif [ "$1" = "check" ]
 then
     ${DOCKER} compose ps
-
-    DEXEC="${DOCKER} compose exec -T -e REFDA_EID=ipn:2.6 amp-manager"
-    MEXEC="${DOCKER} compose exec -T ion-manager"
-    AEXEC="${DOCKER} compose exec -T agent1"
 
     # Wait for necessary daemons to start
     for IX in $(seq 10)

--- a/integration-test-socket/startup.uri
+++ b/integration-test-socket/startup.uri
@@ -1,3 +1,3 @@
 //ietf/dtnma-agent-acl/ctrl/ensure-group(1,test-agents)
-//ietf/dtnma-agent-acl/ctrl/ensure-group-members(1,/ac/(//ietf/network-base/ident/uri-regexp-pattern(%22file%3A.%2A%22)))
+//ietf/dtnma-agent-acl/ctrl/ensure-group-members(1,/ac/(/label/0,//ietf/dtnma-agent/oper/match-regexp(%22file%3A.%2A%22)))
 //ietf/dtnma-agent-acl/CTRL/ensure-access(1,/ac/(1),/ac/(/objpat/(*)(*)(*)(*)),/ac/(//ietf/dtnma-agent-acl/ident/execute,//ietf/dtnma-agent-acl/ident/produce))


### PR DESCRIPTION
This was broken by #263 related to #260. I don't know why tests were passing for that PR.