### PR TITLE
Do not double-count DESTDIR for cmake install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ deps/build
 build
 testroot
 /deps/*/
+/deps/

--- a/deps.sh
+++ b/deps.sh
@@ -32,7 +32,7 @@ BUILDDIR=${BUILDDIR:-${SELFDIR}/deps/build}
 echo "Building in ${BUILDDIR}"
 echo "Installing to ${DESTDIR}"
 
-if [[ "${DEPS_BUILD_ION:-1}" -ne 0 && ! -e ${DESTDIR}/usr/include/ion.h ]]
+if [[ "${DEPS_BUILD_ION:-1}" -ne 0 && ! -e ${DESTDIR}${PREFIX}/include/ion.h ]]
 then
   mkdir -p ${BUILDDIR}
   rsync --recursive ${DEPSDIR}/ion/ ${BUILDDIR}/ion/
@@ -43,7 +43,7 @@ then
   export CC="gcc" CXX="g++"
   export CFLAGS="-std=gnu99 -Wno-error=pedantic"
   ./configure \
-      --prefix=/usr \
+      --prefix=${PREFIX} \
       --disable-dtpc --disable-tc
   make -j$(nproc)
   export -n CC CXX CFLAGS
@@ -52,10 +52,9 @@ then
   export -n LIBTOOLFLAGS
   make -j$(nproc) clean
   popd
-  find ${DESTDIR}/usr/include -type f
 fi
 
-if [[ ! -e ${DESTDIR}/usr/include/qcbor/qcbor.h ]]
+if [[ ! -e ${DESTDIR}${PREFIX}/include/qcbor/qcbor.h ]]
 then
   echo "Building QCBOR..."
   pushd ${DEPSDIR}/QCBOR
@@ -71,7 +70,7 @@ then
   popd
 fi
 
-if [[ ! -e ${DESTDIR}/usr/include/m-lib ]]
+if [[ ! -e ${DESTDIR}${PREFIX}/include/m-lib ]]
 then
   echo "Building MLIB..."
   mkdir -p ${BUILDDIR}/mlib/
@@ -84,7 +83,7 @@ then
   popd
 fi
 
-if [[ ! -e ${DESTDIR}/usr/include/unity ]]
+if [[ ! -e ${DESTDIR}${PREFIX}/include/unity ]]
 then
   echo "Building Unity..."
   pushd ${DEPSDIR}/unity
@@ -99,7 +98,7 @@ then
   popd
 fi
 
-if [[ ! -e ${DESTDIR}/usr/include/timespec.h ]]
+if [[ ! -e ${DESTDIR}${PREFIX}/include/timespec.h ]]
 then
   echo "Building timespec..."
   rsync --recursive ${DEPSDIR}/timespec/ ${BUILDDIR}/timespec/

--- a/deps.sh
+++ b/deps.sh
@@ -59,7 +59,7 @@ then
   patch -p1 <${SELFDIR}/deps/qcbor-increase-depth.patch
   cmake -S . -B ${BUILDDIR}/QCBOR \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_INSTALL_PREFIX=${DESTDIR}${PREFIX} \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DBUILD_SHARED_LIBS=YES
   cmake --build ${BUILDDIR}/QCBOR
   cmake --install ${BUILDDIR}/QCBOR
@@ -88,7 +88,7 @@ then
   export CFLAGS="-DUNITY_USE_COMMAND_LINE_ARGS -DUNITY_INCLUDE_PRINT_FORMATTED -DUNITY_INCLUDE_FLOAT -DUNITY_INCLUDE_DOUBLE"
   cmake -S . -B ${BUILDDIR}/unity \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_INSTALL_PREFIX=${DESTDIR}${PREFIX}
+    -DCMAKE_INSTALL_PREFIX=${PREFIX}
   cmake --build ${BUILDDIR}/unity -v
   export -n CFLAGS
   cmake --install ${BUILDDIR}/unity
@@ -104,7 +104,7 @@ then
   pushd ${BUILDDIR}/timespec
   cmake -S ${BUILDDIR}/timespec -B ${BUILDDIR}/timespec \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_INSTALL_PREFIX=${DESTDIR}${PREFIX} \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DBUILD_TESTING=ON
   cmake --build ${BUILDDIR}/timespec -v
   cmake --build ${BUILDDIR}/timespec --target test

--- a/prep.sh
+++ b/prep.sh
@@ -27,7 +27,7 @@ source ${SELFDIR}/setenv.sh
 
 cmake -S ${SELFDIR} -B ${SELFDIR}/build/default \
   -DCMAKE_PREFIX_PATH=${DESTDIR}${PREFIX} \
-  -DCMAKE_INSTALL_PREFIX=${DESTDIR}${PREFIX} \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_BUILD_TYPE=Debug \
   -G Ninja \
   $@

--- a/setenv.sh
+++ b/setenv.sh
@@ -17,11 +17,20 @@
 ##
 
 SELFDIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-DESTDIR=${DESTDIR:-${SELFDIR}/testroot}
-PREFIX=${PREFIX:-/usr}
 
-if [ -n "${DESTDIR}" -o -n "${PREFIX}" ]
+export DESTDIR=${DESTDIR:-${SELFDIR}/testroot}
+export PREFIX=${PREFIX:-/usr}
+
+if [[ -n "${DESTDIR}" || -n "${PREFIX}" ]]
 then
-    export LD_LIBRARY_PATH=${DESTDIR}${PREFIX}/lib:${DESTDIR}${PREFIX}/lib64
+    if which dpkg-architecture >/dev/null 2>/dev/null
+    then
+        # Debian or Ubuntu
+        LD_LIBRARY_PATH=${DESTDIR}${PREFIX}/lib/$(dpkg-architecture -q DEB_BUILD_MULTIARCH)
+    else
+        # Fedora or RHEL
+        LD_LIBRARY_PATH=${DESTDIR}${PREFIX}/lib:${DESTDIR}${PREFIX}/lib64
+    fi
+    export LD_LIBRARY_PATH
     export PATH=${PATH}:${DESTDIR}${PREFIX}/bin
 fi

--- a/setenv.sh
+++ b/setenv.sh
@@ -26,7 +26,7 @@ then
     if which dpkg-architecture >/dev/null 2>/dev/null
     then
         # Debian or Ubuntu
-        LD_LIBRARY_PATH=${DESTDIR}${PREFIX}/lib/$(dpkg-architecture -q DEB_BUILD_MULTIARCH)
+        LD_LIBRARY_PATH=${DESTDIR}${PREFIX}/lib:${DESTDIR}${PREFIX}/lib/$(dpkg-architecture -q DEB_BUILD_MULTIARCH)
     else
         # Fedora or RHEL
         LD_LIBRARY_PATH=${DESTDIR}${PREFIX}/lib:${DESTDIR}${PREFIX}/lib64


### PR DESCRIPTION
This is a cross-port from a BSL fix