### PR TITLE
Cleanup and constrain includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,8 +46,22 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros: []
-IncludeBlocks:   Preserve
-IncludeCategories:  []
+IncludeBlocks: Regroup
+IncludeCategories:
+ - Regex: '^["<]refda/adm/'
+   Priority: 20
+   SortPriority: 22
+ - Regex: '^["<](refda|refdm)/'
+   Priority: 20
+   SortPriority: 20
+ - Regex: '^["<]cace/'
+   Priority: 30
+ - Regex: '^".*'
+   Priority: 10
+ - Regex: '^<(m-|qcbor|timespec.h)'
+   Priority: 40
+ - Regex: '^<'
+   Priority: 50
 IncludeIsMainRegex: '$'
 IndentCaseLabels: true
 IndentExternBlock: NoIndent
@@ -68,7 +82,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments:  true
-SortIncludes:    false # more strict than cFS
+SortIncludes: CaseInsensitive
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements

--- a/src/cace/amm/idseg_val.h
+++ b/src/cace/amm/idseg_val.h
@@ -19,6 +19,7 @@
 #define CACE_AMM_IDSEG_VAL_H_
 
 #include "idseg_ref.h"
+
 #include "cace/util/defs.h"
 
 #ifdef __cplusplus

--- a/src/cace/amm/lookup.c
+++ b/src/cace/amm/lookup.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "lookup.h"
+
 #include "cace/util/defs.h"
 
 void cace_amm_lookup_init(cace_amm_lookup_t *res)

--- a/src/cace/amm/lookup.h
+++ b/src/cace/amm/lookup.h
@@ -22,10 +22,11 @@
 #ifndef CACE_AMM_LOOKUP_H_
 #define CACE_AMM_LOOKUP_H_
 
-#include "obj_ns.h"
 #include "obj_desc.h"
+#include "obj_ns.h"
 #include "obj_store.h"
 #include "parameters.h"
+
 #include "cace/ari.h"
 
 #ifdef __cplusplus

--- a/src/cace/amm/named_type.c
+++ b/src/cace/amm/named_type.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "named_type.h"
+
 #include "cace/util/defs.h"
 
 void cace_amm_named_type_init(cace_amm_named_type_t *obj)

--- a/src/cace/amm/named_type.h
+++ b/src/cace/amm/named_type.h
@@ -19,8 +19,9 @@
 #define CACE_AMM_NAMED_TYPE_H_
 
 #include "typing.h"
-#include <m-string.h>
+
 #include <m-array.h>
+#include <m-string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/amm/numeric.c
+++ b/src/cace/amm/numeric.c
@@ -16,10 +16,12 @@
  * limitations under the License.
  */
 #include "numeric.h"
+
 #include "promote.h"
+
 #include "cace/amm/typing.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 bool cace_has_numeric_prim_type(const cace_ari_t *obj)
 {

--- a/src/cace/amm/obj_desc.h
+++ b/src/cace/amm/obj_desc.h
@@ -19,9 +19,10 @@
 #define CACE_AMM_OBJ_DESC_H_
 
 #include "idseg_val.h"
-#include "user_data.h"
 #include "parameters.h"
 #include "status.h"
+#include "user_data.h"
+
 #include "cace/ari.h"
 #include "cace/util/nocase.h"
 

--- a/src/cace/amm/obj_ns.c
+++ b/src/cace/amm/obj_ns.c
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 #include "obj_ns.h"
+
 #include "obj_org.h"
+
 #include "cace/ari/text.h"
 #include "cace/util/logging.h"
 

--- a/src/cace/amm/obj_ns.h
+++ b/src/cace/amm/obj_ns.h
@@ -18,12 +18,14 @@
 #ifndef CACE_AMM_OBJ_NS_H_
 #define CACE_AMM_OBJ_NS_H_
 
-#include "obj_desc.h"
-#include "idseg_val.h"
 #include "idseg_ref.h"
+#include "idseg_val.h"
+#include "obj_desc.h"
+
 #include "cace/ari/ref.h"
 #include "cace/util/defs.h"
 #include "cace/util/nocase.h"
+
 #include <m-rbtree.h>
 #include <m-shared-ptr.h>
 

--- a/src/cace/amm/obj_org.c
+++ b/src/cace/amm/obj_org.c
@@ -16,8 +16,9 @@
  * limitations under the License.
  */
 #include "obj_org.h"
-#include "cace/util/logging.h"
+
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 void cace_amm_obj_org_init(cace_amm_obj_org_t *org)
 {

--- a/src/cace/amm/obj_org.h
+++ b/src/cace/amm/obj_org.h
@@ -18,11 +18,13 @@
 #ifndef CACE_AMM_OBJ_ORG_H_
 #define CACE_AMM_OBJ_ORG_H_
 
-#include "obj_ns.h"
 #include "idseg_val.h"
+#include "obj_ns.h"
+
 #include "cace/util/nocase.h"
-#include <m-shared-ptr.h>
+
 #include <m-rbtree.h>
+#include <m-shared-ptr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/amm/obj_store.c
+++ b/src/cace/amm/obj_store.c
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 #include "obj_store.h"
+
 #include "cace/ari/text_util.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 void cace_amm_obj_store_init(cace_amm_obj_store_t *store)
 {

--- a/src/cace/amm/obj_store.h
+++ b/src/cace/amm/obj_store.h
@@ -18,11 +18,13 @@
 #ifndef CACE_AMM_OBJ_STORE_H_
 #define CACE_AMM_OBJ_STORE_H_
 
-#include "obj_org.h"
 #include "idseg_ref.h"
+#include "obj_org.h"
+
 #include "cace/util/nocase.h"
-#include <m-shared-ptr.h>
+
 #include <m-rbtree.h>
+#include <m-shared-ptr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/amm/objpat_set.c
+++ b/src/cace/amm/objpat_set.c
@@ -16,8 +16,9 @@
  * limitations under the License.
  */
 #include "objpat_set.h"
-#include "cace/util/logging.h"
+
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 /** Only copy actual OBJPAT values, keep same order from source.
  */

--- a/src/cace/amm/objpat_set.h
+++ b/src/cace/amm/objpat_set.h
@@ -24,7 +24,9 @@
 #define CACE_AMM_OBJPAT_SET_H_
 
 #include "lookup.h"
+
 #include "cace/ari/objpat.h"
+
 #include <m-dict.h>
 
 #ifdef __cplusplus

--- a/src/cace/amm/parameters.c
+++ b/src/cace/amm/parameters.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "parameters.h"
+
 #include "cace/ari/text.h"
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"

--- a/src/cace/amm/parameters.h
+++ b/src/cace/amm/parameters.h
@@ -19,6 +19,7 @@
 #define CACE_AMM_PARAMETERS_H_
 
 #include "typing.h"
+
 #include "cace/ari.h"
 #include "cace/ari/itemized.h"
 #include "cace/config.h"

--- a/src/cace/amm/promote.c
+++ b/src/cace/amm/promote.c
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 #include "promote.h"
+
 #include "typing.h"
-#include "cace/util/logging.h"
+
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 cace_ari_type_t cace_amm_promote_eqiv_lit_type(const cace_ari_lit_t *lit)
 {

--- a/src/cace/amm/semtype.c
+++ b/src/cace/amm/semtype.c
@@ -16,12 +16,15 @@
  * limitations under the License.
  */
 #include "semtype.h"
+
 #include "lookup.h"
+
 #include "cace/ari/algo.h"
 #include "cace/ari/text.h"
+#include "cace/config.h"
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"
-#include "cace/config.h"
+
 #include <m-dict.h>
 
 static bool cace_amm_semtype_use_constraints(const cace_amm_semtype_use_t *semtype, const cace_ari_t *val)

--- a/src/cace/amm/semtype.h
+++ b/src/cace/amm/semtype.h
@@ -22,10 +22,12 @@
 #ifndef CACE_AMM_SEMTYPE_H_
 #define CACE_AMM_SEMTYPE_H_
 
-#include "typing.h"
 #include "named_type.h"
 #include "semtype_cnst.h"
+#include "typing.h"
+
 #include "cace/util/range.h"
+
 #include <m-array.h>
 
 #ifdef __cplusplus

--- a/src/cace/amm/semtype_cnst.c
+++ b/src/cace/amm/semtype_cnst.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "semtype_cnst.h"
+
 #include "cace/util/logging.h"
 
 void cace_amm_semtype_cnst_init(cace_amm_semtype_cnst_t *obj)

--- a/src/cace/amm/semtype_cnst.h
+++ b/src/cace/amm/semtype_cnst.h
@@ -22,9 +22,9 @@
 #ifndef CACE_AMM_SEMTYPE_USE_H_
 #define CACE_AMM_SEMTYPE_USE_H_
 
-#include "cace/util/range.h"
-#include "cace/config.h"
 #include "cace/ari.h"
+#include "cace/config.h"
+#include "cace/util/range.h"
 #if PCRE_FOUND
 #include <pcre2.h>
 #endif /* PCRE_FOUND */

--- a/src/cace/amm/status.h
+++ b/src/cace/amm/status.h
@@ -23,8 +23,9 @@
 #define CACE_AMM_STATUS_H_
 
 #include "idseg_val.h"
-#include "user_data.h"
 #include "parameters.h"
+#include "user_data.h"
+
 #include "cace/ari.h"
 #include "cace/util/nocase.h"
 

--- a/src/cace/amm/typing.c
+++ b/src/cace/amm/typing.c
@@ -16,19 +16,23 @@
  * limitations under the License.
  */
 #include "typing.h"
+
 #include "lookup.h"
 #include "semtype.h"
-#include "cace/ari/type.h"
+
 #include "cace/ari/algo.h"
 #include "cace/ari/text.h"
+#include "cace/ari/type.h"
+#include "cace/config.h"
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"
-#include "cace/config.h"
+
 #include <m-dict.h>
-#include <pthread.h>
-#include <math.h>
-#include <float.h>
+
 #include <fenv.h>
+#include <float.h>
+#include <math.h>
+#include <pthread.h>
 
 /// Name any builtin type
 static void builtin_ari_name(const cace_amm_type_t *self, cace_ari_t *name)

--- a/src/cace/amm/typing.h
+++ b/src/cace/amm/typing.h
@@ -24,6 +24,7 @@
 
 #include "cace/ari.h"
 #include "cace/cace_data.h"
+
 #include <m-array.h>
 
 #ifdef __cplusplus

--- a/src/cace/amm/user_data.h
+++ b/src/cace/amm/user_data.h
@@ -23,6 +23,7 @@
 #define CACE_AMM_USER_DATA_H_
 
 #include "parameters.h"
+
 #include "cace/ari.h"
 #include "cace/util/nocase.h"
 

--- a/src/cace/amp/ion_bp.c
+++ b/src/cace/amp/ion_bp.c
@@ -21,11 +21,13 @@
  * Provide an ION BP adapter for AMP messaging.
  */
 #include "ion_bp.h"
+
 #include "msg.h"
+
 #include "cace/ari/text.h"
 #include "cace/ari/time_util.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 #if ION_FOUND
 #include <bp.h>

--- a/src/cace/amp/msg.c
+++ b/src/cace/amp/msg.c
@@ -16,10 +16,12 @@
  * limitations under the License.
  */
 #include "msg.h"
+
 #include "cace/ari/cbor.h"
 #include "cace/ari/text.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <qcbor/qcbor_spiffy_decode.h>
 
 int cace_amp_msg_encode(m_bstring_t msgbuf, const cace_ari_list_t items)

--- a/src/cace/amp/msg.c
+++ b/src/cace/amp/msg.c
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 #include "msg.h"
-#include <cace/ari/cbor.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/ari/cbor.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 #include <qcbor/qcbor_spiffy_decode.h>
 
 int cace_amp_msg_encode(m_bstring_t msgbuf, const cace_ari_list_t items)

--- a/src/cace/amp/msg.h
+++ b/src/cace/amp/msg.h
@@ -23,6 +23,7 @@
 #define CACE_AMP_MSG_H_
 
 #include "cace/ari/containers.h"
+
 #include <m-bstring.h>
 
 #ifdef __cplusplus

--- a/src/cace/amp/proxy_cli.c
+++ b/src/cace/amp/proxy_cli.c
@@ -16,20 +16,24 @@
  * limitations under the License.
  */
 #include "proxy_cli.h"
+
 #include "msg.h"
+
 #include "cace/ari/cbor.h"
 #include "cace/ari/text.h"
 #include "cace/ari/time_util.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
-#include <timespec.h>
-#include <qcbor/qcbor.h>
+
 #include <m-bstring.h>
+#include <qcbor/qcbor.h>
+#include <timespec.h>
+
+#include <errno.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
-#include <errno.h>
 
 void cace_amp_proxy_cli_state_init(cace_amp_proxy_cli_state_t *state)
 {

--- a/src/cace/amp/proxy_cli.h
+++ b/src/cace/amp/proxy_cli.h
@@ -25,7 +25,9 @@
 
 #include "cace/amm/msg_if.h"
 #include "cace/ari.h"
+
 #include <m-string.h>
+
 #include <pthread.h>
 
 #ifdef __cplusplus

--- a/src/cace/amp/proxy_msg.c
+++ b/src/cace/amp/proxy_msg.c
@@ -16,13 +16,16 @@
  * limitations under the License.
  */
 #include "proxy_msg.h"
+
 #include "cace/ari/cbor.h"
 #include "cace/ari/text.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <qcbor/qcbor.h>
-#include <sys/socket.h>
+
 #include <errno.h>
+#include <sys/socket.h>
 
 int cace_amp_proxy_msg_send(int sock_fd, const cace_ari_t *dst, const uint8_t *data_ptr, size_t data_len)
 {

--- a/src/cace/amp/proxy_msg.h
+++ b/src/cace/amp/proxy_msg.h
@@ -24,6 +24,7 @@
 #define CACE_AMP_PROXY_MSG_H_
 
 #include "cace/ari.h"
+
 #include <m-bstring.h>
 
 #ifdef __cplusplus

--- a/src/cace/amp/socket.c
+++ b/src/cace/amp/socket.c
@@ -23,8 +23,8 @@
 #include "msg.h"
 #include "cace/ari/text.h"
 #include "cace/ari/time_util.h"
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 #include <m-bstring.h>
 #include <sys/poll.h>
 #include <sys/socket.h>

--- a/src/cace/amp/socket.c
+++ b/src/cace/amp/socket.c
@@ -20,19 +20,23 @@
  * Provide a POSIX datagram socket (AF_UNIX) adapter for AMP messaging.
  */
 #include "socket.h"
+
 #include "msg.h"
+
 #include "cace/ari/text.h"
 #include "cace/ari/time_util.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <m-bstring.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <strings.h>
 #include <sys/poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <signal.h>
-#include <strings.h>
 #include <unistd.h>
-#include <errno.h>
 
 static const char *URI_PREFIX = "file:";
 

--- a/src/cace/ari.h
+++ b/src/cace/ari.h
@@ -25,9 +25,9 @@
 #ifndef CACE_ARI_H_
 #define CACE_ARI_H_
 
-#include "ari/base.h"
-#include "ari/containers.h"
 #include "ari/access.h"
 #include "ari/algo.h"
+#include "ari/base.h"
+#include "ari/containers.h"
 
 #endif /* CACE_ARI_H_ */

--- a/src/cace/ari/access.c
+++ b/src/cace/ari/access.c
@@ -16,8 +16,11 @@
  * limitations under the License.
  */
 #include "access.h"
+
 #include "objpat.h"
+
 #include "cace/util/defs.h"
+
 #include <timespec.h>
 
 bool cace_ari_is_undefined(const cace_ari_t *ari)

--- a/src/cace/ari/algo.c
+++ b/src/cace/ari/algo.c
@@ -16,13 +16,16 @@
  * limitations under the License.
  */
 #include "algo.h"
+
 #include "containers.h"
 #include "objpat.h"
 #include "text.h"
-#include "cace/util/logging.h"
-#include "cace/util/defs.h"
+
 #include "cace/amm/numeric.h"
 #include "cace/amm/typing.h"
+#include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <math.h>
 
 static int cace_ari_visit_ari(cace_ari_t *ari, const cace_ari_visitor_t *visitor, const cace_ari_visit_ctx_t *ctx);

--- a/src/cace/ari/base.c
+++ b/src/cace/ari/base.c
@@ -19,10 +19,13 @@
  * @ingroup group_ari
  */
 #include "base.h"
+
+#include "containers.h"
 #include "lit.h"
 #include "ref.h"
-#include "containers.h"
+
 #include "cace/util/defs.h"
+
 #include <inttypes.h>
 
 /** Reset the state of a value struct.

--- a/src/cace/ari/base.h
+++ b/src/cace/ari/base.h
@@ -25,17 +25,20 @@
 #ifndef CACE_ARI_BASE_H_
 #define CACE_ARI_BASE_H_
 
-#include "type.h"
 #include "lit.h"
 #include "ref.h"
-#include "cace/config.h"
+#include "type.h"
+
 #include "cace/cace_data.h"
-#include <m-string.h>
-#include <m-list.h>
+#include "cace/config.h"
+
 #include <m-dict.h>
-#include <time.h>
-#include <stdint.h>
+#include <m-list.h>
+#include <m-string.h>
+
 #include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/ari/cbor.c
+++ b/src/cace/ari/cbor.c
@@ -23,11 +23,14 @@
  * the AMM can be uniquely identified using an ARI.
  */
 #include "cbor.h"
+
 #include "access.h"
 #include "objpat.h"
 #include "text_util.h"
+
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"
+
 #include <qcbor/qcbor_spiffy_decode.h>
 
 int cace_ari_cbor_encode(cace_data_t *buf, const cace_ari_t *ari)

--- a/src/cace/ari/cbor.h
+++ b/src/cace/ari/cbor.h
@@ -24,11 +24,14 @@
 
 #include "base.h"
 #include "containers.h"
+
 #include "cace/cace_data.h"
-#include <qcbor/qcbor_encode.h>
+
 #include <qcbor/qcbor_decode.h>
-#include <stdint.h>
+#include <qcbor/qcbor_encode.h>
+
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/ari/containers.c
+++ b/src/cace/ari/containers.c
@@ -19,8 +19,10 @@
  * @ingroup group_ari
  */
 #include "containers.h"
-#include "cace/util/logging.h"
+
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <inttypes.h>
 
 /// CMP operation not defined by M*LIB

--- a/src/cace/ari/containers.h
+++ b/src/cace/ari/containers.h
@@ -25,8 +25,9 @@
 #ifndef CACE_ARI_CONTAINERS_H_
 #define CACE_ARI_CONTAINERS_H_
 
-#include "base.h"
 #include "algo.h"
+#include "base.h"
+
 #include <m-array.h>
 #include <m-bptree.h>
 #include <m-deque.h>

--- a/src/cace/ari/idseg.c
+++ b/src/cace/ari/idseg.c
@@ -19,8 +19,11 @@
  * @ingroup group_ari
  */
 #include "idseg.h"
+
 #include "text_util.h"
+
 #include "cace/util/defs.h"
+
 #include <inttypes.h>
 
 void cace_ari_idseg_init(cace_ari_idseg_t *idseg)

--- a/src/cace/ari/idseg.h
+++ b/src/cace/ari/idseg.h
@@ -24,10 +24,13 @@
 #define CACE_ARI_IDSEG_H_
 
 #include "type.h"
+
 #include "cace/config.h"
+
 #include <m-string.h>
-#include <stdint.h>
+
 #include <stdbool.h>
+#include <stdint.h>
 #include <time.h>
 
 #ifdef __cplusplus

--- a/src/cace/ari/itemized.c
+++ b/src/cace/ari/itemized.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "itemized.h"
+
 #include "cace/util/defs.h"
 
 void cace_ari_itemized_init(cace_ari_itemized_t *obj)

--- a/src/cace/ari/itemized.h
+++ b/src/cace/ari/itemized.h
@@ -26,7 +26,9 @@
 
 #include "base.h"
 #include "containers.h"
+
 #include "cace/config.h"
+
 #include <m-dict.h>
 
 #ifdef __cplusplus

--- a/src/cace/ari/lit.c
+++ b/src/cace/ari/lit.c
@@ -19,9 +19,12 @@
  * @ingroup group_ari
  */
 #include "lit.h"
+
 #include "containers.h"
 #include "objpat.h"
+
 #include "cace/util/defs.h"
+
 #include <inttypes.h>
 
 const time_t cace_ari_dtn_epoch = CACE_ARI_DTN_EPOCH;

--- a/src/cace/ari/lit.h
+++ b/src/cace/ari/lit.h
@@ -22,16 +22,19 @@
 #ifndef CACE_ARI_LIT_H_
 #define CACE_ARI_LIT_H_
 
-#include "type.h"
 #include "idseg.h"
-#include "cace/config.h"
+#include "type.h"
+
 #include "cace/cace_data.h"
-#include <m-string.h>
-#include <m-list.h>
+#include "cace/config.h"
+
 #include <m-dict.h>
-#include <time.h>
-#include <stdint.h>
+#include <m-list.h>
+#include <m-string.h>
+
 #include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/ari/macrofile.c
+++ b/src/cace/ari/macrofile.c
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 #include "macrofile.h"
+
 #include "text.h"
-#include "cace/util/logging.h"
+
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 #if ARI_TEXT_PARSE
 

--- a/src/cace/ari/objpat.h
+++ b/src/cace/ari/objpat.h
@@ -24,10 +24,13 @@
 #define CACE_ARI_OBJPAT_H_
 
 #include "base.h"
-#include "cace/util/range.h"
+
 #include "cace/config.h"
+#include "cace/util/range.h"
+
 #include <m-string.h>
 #include <m-variant.h>
+
 #include <stdbool.h>
 
 #ifdef __cplusplus

--- a/src/cace/ari/ref.c
+++ b/src/cace/ari/ref.c
@@ -19,10 +19,13 @@
  * @ingroup group_ari
  */
 #include "ref.h"
+
 #include "containers.h"
 #include "text_util.h"
-#include "cace/util/logging.h"
+
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <inttypes.h>
 
 void cace_ari_date_init(cace_ari_date_t *obj)

--- a/src/cace/ari/ref.h
+++ b/src/cace/ari/ref.h
@@ -25,10 +25,13 @@
 
 #include "idseg.h"
 #include "type.h"
+
 #include "cace/config.h"
+
 #include <m-string.h>
-#include <stdint.h>
+
 #include <stdbool.h>
+#include <stdint.h>
 #include <time.h>
 
 #ifdef __cplusplus

--- a/src/cace/ari/text.h
+++ b/src/cace/ari/text.h
@@ -24,10 +24,13 @@
 
 #include "base.h"
 #include "containers.h"
+
 #include "cace/config.h"
+
 #include <m-string.h>
-#include <stdint.h>
+
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/ari/text_enc.c
+++ b/src/cace/ari/text_enc.c
@@ -15,12 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "text.h"
-#include "text_util.h"
 #include "access.h"
 #include "objpat.h"
+#include "text.h"
+#include "text_util.h"
+
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"
+
 #include <inttypes.h>
 
 typedef struct

--- a/src/cace/ari/text_util.c
+++ b/src/cace/ari/text_util.c
@@ -16,14 +16,17 @@
  * limitations under the License.
  */
 #include "text_util.h"
+
 #include "lit.h"
+
 #include "cace/util/defs.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <inttypes.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <math.h>
 
 /** Get the size of text ignoring a terminating null.
  */

--- a/src/cace/ari/text_util.h
+++ b/src/cace/ari/text_util.h
@@ -23,7 +23,9 @@
 #define CACE_ARI_TEXT_UTIL_H_
 
 #include "cace/cace_data.h"
+
 #include <m-string.h>
+
 #include <stdint.h>
 #include <time.h>
 

--- a/src/cace/ari/type.c
+++ b/src/cace/ari/type.c
@@ -16,9 +16,12 @@
  * limitations under the License.
  */
 #include "type.h"
+
 #include "cace/util/defs.h"
 #include "cace/util/nocase.h"
+
 #include <m-dict.h>
+
 #include <pthread.h>
 #include <stddef.h>
 

--- a/src/cace/ari/type.h
+++ b/src/cace/ari/type.h
@@ -23,6 +23,7 @@
 #define CACE_ARI_TYPE_H_
 
 #include "cace/config.h"
+
 #include <inttypes.h>
 
 #ifdef __cplusplus

--- a/src/cace/cace_ari.c
+++ b/src/cace/cace_ari.c
@@ -15,12 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cace/config.h>
-#include <cace/ari.h>
-#include <cace/ari/text.h>
-#include <cace/ari/cbor.h>
-#include <cace/ari/text_util.h>
-#include <cace/util/logging.h>
+#include "cace/config.h"
+#include "cace/ari.h"
+#include "cace/ari/text.h"
+#include "cace/ari/cbor.h"
+#include "cace/ari/text_util.h"
+#include "cace/util/logging.h"
 #include <qcbor/qcbor_decode.h>
 #include <getopt.h>
 #include <errno.h>

--- a/src/cace/cace_ari.c
+++ b/src/cace/cace_ari.c
@@ -15,15 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cace/config.h"
 #include "cace/ari.h"
-#include "cace/ari/text.h"
 #include "cace/ari/cbor.h"
+#include "cace/ari/text.h"
 #include "cace/ari/text_util.h"
+#include "cace/config.h"
 #include "cace/util/logging.h"
+
 #include <qcbor/qcbor_decode.h>
-#include <getopt.h>
+
 #include <errno.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>

--- a/src/cace/cace_data.c
+++ b/src/cace/cace_data.c
@@ -19,9 +19,12 @@
  * @ingroup group_ari
  */
 #include "cace_data.h"
+
 #include "cace/util/defs.h"
+
 #include <m-core.h>
 #include <m-string.h>
+
 #include <string.h>
 
 static void cace_data_int_reset(cace_data_t *data)

--- a/src/cace/cace_data.h
+++ b/src/cace/cace_data.h
@@ -26,11 +26,13 @@
 #define CACE_CACE_DATA_H_
 
 #include "cace/config.h"
-#include <sys/types.h>
+
 #include <m-core.h>
+
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/util/daemon_run.c
+++ b/src/cace/util/daemon_run.c
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 #include "daemon_run.h"
+
 #include "logging.h"
+
 #include <errno.h>
 
 /**

--- a/src/cace/util/daemon_run.h
+++ b/src/cace/util/daemon_run.h
@@ -22,8 +22,8 @@
 #ifndef CACE_UTIL_DAEMON_RUN_H_
 #define CACE_UTIL_DAEMON_RUN_H_
 
-#include <stdbool.h>
 #include <semaphore.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/util/logging.h
+++ b/src/cace/util/logging.h
@@ -40,8 +40,8 @@
 #ifndef CACE_LOGGING_H_
 #define CACE_LOGGING_H_
 
-#include <syslog.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/util/logging_stderr.c
+++ b/src/cace/util/logging_stderr.c
@@ -15,12 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cace/config.h"
-#include "logging.h"
 #include "defs.h"
+#include "logging.h"
+
+#include "cace/config.h"
+
+#include <m-atomic.h>
 #include <m-buffer.h>
 #include <m-string.h>
-#include <m-atomic.h>
+
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/cace/util/mutex.h
+++ b/src/cace/util/mutex.h
@@ -23,8 +23,8 @@
 #ifndef CACE_MUTEX_H_
 #define CACE_MUTEX_H_
 
-#include "logging.h"
 #include "defs.h"
+#include "logging.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cace/util/nocase.h
+++ b/src/cace/util/nocase.h
@@ -23,6 +23,7 @@
 #define CACE_NOCASE_H_
 
 #include <m-string.h>
+
 #include <strings.h>
 
 /* HASH function for a C-string (to be used within oplist)

--- a/src/cace/util/range.h
+++ b/src/cace/util/range.h
@@ -24,6 +24,7 @@
 
 #include "cace/config.h"
 #include "cace/util/defs.h"
+
 #include <m-rbtree.h>
 
 #ifdef __cplusplus

--- a/src/cace/util/threadset.c
+++ b/src/cace/util/threadset.c
@@ -17,8 +17,10 @@
  */
 
 #include "threadset.h"
-#include "logging.h"
+
 #include "defs.h"
+#include "logging.h"
+
 #include <errno.h>
 
 int cace_threadset_start(cace_threadset_t tset, const cace_threadinfo_t *info, size_t count, void *arg)

--- a/src/cace/util/threadset.h
+++ b/src/cace/util/threadset.h
@@ -23,8 +23,10 @@
 #define CACE_UTIL_THREADSET_H_
 
 #include "cace/config.h"
-#include <pthread.h>
+
 #include <m-list.h>
+
+#include <pthread.h>
 
 /// @cond Doxygen_Suppress
 M_LIST_DEF(cace_threadset, pthread_t)

--- a/src/ion-app-proxy/main.c
+++ b/src/ion-app-proxy/main.c
@@ -15,22 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cace/amp/proxy_msg.h"
 #include "cace/amp/ion_bp.h"
+#include "cace/amp/proxy_msg.h"
 #include "cace/ari/text.h"
-#include "cace/util/threadset.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+#include "cace/util/threadset.h"
+
 #include <m-bstring.h>
-#include <m-shared-ptr.h>
 #include <m-buffer.h>
-#include <signal.h>
-#include <getopt.h>
+#include <m-shared-ptr.h>
+
+#include <bp.h>
 #include <errno.h>
+#include <getopt.h>
+#include <signal.h>
 #include <sys/poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <bp.h>
 #if defined(HAVE_LIBSYSTEMD)
 #include <systemd/sd-daemon.h>
 #endif

--- a/src/refda-ion/main.c
+++ b/src/refda-ion/main.c
@@ -19,11 +19,13 @@
 #include "refda/loader.h"
 #include "refda/adm/ietf.h"
 #include "refda/adm/ietf_dtnma_agent.h"
+
 #include "cace/amp/ion_bp.h"
-#include "cace/ari/text.h"
 #include "cace/ari/macrofile.h"
-#include "cace/util/logging.h"
+#include "cace/ari/text.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <bp.h>
 #include <signal.h>
 #include <unistd.h>

--- a/src/refda-ion/main.c
+++ b/src/refda-ion/main.c
@@ -19,11 +19,11 @@
 #include "refda/loader.h"
 #include "refda/adm/ietf.h"
 #include "refda/adm/ietf_dtnma_agent.h"
-#include <cace/amp/ion_bp.h>
-#include <cace/ari/text.h>
-#include <cace/ari/macrofile.h>
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/amp/ion_bp.h"
+#include "cace/ari/text.h"
+#include "cace/ari/macrofile.h"
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 #include <bp.h>
 #include <signal.h>
 #include <unistd.h>

--- a/src/refda-socket/main.c
+++ b/src/refda-socket/main.c
@@ -19,11 +19,13 @@
 #include "refda/loader.h"
 #include "refda/adm/ietf.h"
 #include "refda/adm/ietf_dtnma_agent.h"
+
 #include "cace/amp/socket.h"
-#include "cace/ari/text.h"
 #include "cace/ari/macrofile.h"
-#include "cace/util/logging.h"
+#include "cace/ari/text.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <signal.h>
 #include <unistd.h>
 

--- a/src/refda-socket/main.c
+++ b/src/refda-socket/main.c
@@ -19,11 +19,11 @@
 #include "refda/loader.h"
 #include "refda/adm/ietf.h"
 #include "refda/adm/ietf_dtnma_agent.h"
-#include <cace/amp/socket.h>
-#include <cace/ari/text.h>
-#include <cace/ari/macrofile.h>
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/amp/socket.h"
+#include "cace/ari/text.h"
+#include "cace/ari/macrofile.h"
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 #include <signal.h>
 #include <unistd.h>
 

--- a/src/refda-stdio/main.c
+++ b/src/refda-stdio/main.c
@@ -17,13 +17,13 @@
  */
 #include "refda/agent.h"
 #include "refda/loader.h"
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
-#include <cace/ari/text_util.h>
-#include <cace/ari/text.h>
-#include <cace/ari/macrofile.h>
-#include <cace/ari/time_util.h>
-#include <cace/ari/cbor.h>
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
+#include "cace/ari/text_util.h"
+#include "cace/ari/text.h"
+#include "cace/ari/macrofile.h"
+#include "cace/ari/time_util.h"
+#include "cace/ari/cbor.h"
 #include <sys/poll.h>
 #include <signal.h>
 #include <unistd.h>

--- a/src/refda-stdio/main.c
+++ b/src/refda-stdio/main.c
@@ -17,15 +17,17 @@
  */
 #include "refda/agent.h"
 #include "refda/loader.h"
-#include "cace/util/logging.h"
-#include "cace/util/defs.h"
-#include "cace/ari/text_util.h"
-#include "cace/ari/text.h"
-#include "cace/ari/macrofile.h"
-#include "cace/ari/time_util.h"
+
 #include "cace/ari/cbor.h"
-#include <sys/poll.h>
+#include "cace/ari/macrofile.h"
+#include "cace/ari/text.h"
+#include "cace/ari/text_util.h"
+#include "cace/ari/time_util.h"
+#include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <signal.h>
+#include <sys/poll.h>
 #include <unistd.h>
 
 /// Per-process state

--- a/src/refda/acl.c
+++ b/src/refda/acl.c
@@ -17,10 +17,10 @@
  */
 #include "acl.h"
 #include "eval.h"
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 void refda_acl_group_init(refda_acl_group_t *obj)
 {

--- a/src/refda/acl.c
+++ b/src/refda/acl.c
@@ -16,11 +16,13 @@
  * limitations under the License.
  */
 #include "acl.h"
+
 #include "eval.h"
+
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 void refda_acl_group_init(refda_acl_group_t *obj)
 {

--- a/src/refda/acl.h
+++ b/src/refda/acl.h
@@ -19,12 +19,15 @@
 #define REFDA_ACL_H_
 
 #include "amm/ident.h"
+
 #include "cace/amm/objpat_set.h"
 #include "cace/ari/base.h"
+
 #include <m-atomic.h>
+#include <m-bptree.h>
 #include <m-deque.h>
 #include <m-rbtree.h>
-#include <m-bptree.h>
+
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/src/refda/adm/iana_display_hints.c
+++ b/src/refda/adm/iana_display_hints.c
@@ -24,17 +24,19 @@
  */
 
 #include "iana_display_hints.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
 #include "refda/reporting.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/iana_display_hints.c
+++ b/src/refda/adm/iana_display_hints.c
@@ -30,11 +30,11 @@
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
 #include "refda/reporting.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/iana_display_hints.h
+++ b/src/refda/adm/iana_display_hints.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IANA_DISPLAY_HINTS_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/iana_display_hints.h
+++ b/src/refda/adm/iana_display_hints.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IANA_DISPLAY_HINTS_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_alarms.c
+++ b/src/refda/adm/ietf_alarms.c
@@ -24,16 +24,18 @@
  */
 
 #include "ietf_alarms.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 #include "ietf.h"

--- a/src/refda/adm/ietf_alarms.c
+++ b/src/refda/adm/ietf_alarms.c
@@ -29,11 +29,11 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 #include "ietf.h"

--- a/src/refda/adm/ietf_alarms.h
+++ b/src/refda/adm/ietf_alarms.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IETF_ALARMS_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_alarms.h
+++ b/src/refda/adm/ietf_alarms.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IETF_ALARMS_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_amm.c
+++ b/src/refda/adm/ietf_amm.c
@@ -29,12 +29,12 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*   STOP CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_amm.c
+++ b/src/refda/adm/ietf_amm.c
@@ -24,17 +24,18 @@
  */
 
 #include "ietf_amm.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*   STOP CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_amm.h
+++ b/src/refda/adm/ietf_amm.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IETF_AMM_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_amm.h
+++ b/src/refda/adm/ietf_amm.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IETF_AMM_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_amm_base.c
+++ b/src/refda/adm/ietf_amm_base.c
@@ -30,11 +30,11 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */
 /*             TODO              */

--- a/src/refda/adm/ietf_amm_base.c
+++ b/src/refda/adm/ietf_amm_base.c
@@ -25,16 +25,18 @@
  */
 
 #include "ietf_amm_base.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */
 /*             TODO              */

--- a/src/refda/adm/ietf_amm_base.h
+++ b/src/refda/adm/ietf_amm_base.h
@@ -28,6 +28,7 @@
 #define REFDA_ADM_IETF_AMM_BASE_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */

--- a/src/refda/adm/ietf_amm_base.h
+++ b/src/refda/adm/ietf_amm_base.h
@@ -28,7 +28,7 @@
 #define REFDA_ADM_IETF_AMM_BASE_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */
 /*             TODO              */

--- a/src/refda/adm/ietf_amm_semtype.c
+++ b/src/refda/adm/ietf_amm_semtype.c
@@ -24,16 +24,18 @@
  */
 
 #include "ietf_amm_semtype.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_amm_semtype.c
+++ b/src/refda/adm/ietf_amm_semtype.c
@@ -29,11 +29,11 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_amm_semtype.h
+++ b/src/refda/adm/ietf_amm_semtype.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IETF_AMM_SEMTYPE_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_amm_semtype.h
+++ b/src/refda/adm/ietf_amm_semtype.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IETF_AMM_SEMTYPE_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_bp_base.c
+++ b/src/refda/adm/ietf_bp_base.c
@@ -24,16 +24,18 @@
  */
 
 #include "ietf_bp_base.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_bp_base.c
+++ b/src/refda/adm/ietf_bp_base.c
@@ -29,11 +29,11 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_bp_base.h
+++ b/src/refda/adm/ietf_bp_base.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IETF_BP_BASE_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_bp_base.h
+++ b/src/refda/adm/ietf_bp_base.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IETF_BP_BASE_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_dtnma_agent.c
+++ b/src/refda/adm/ietf_dtnma_agent.c
@@ -25,27 +25,32 @@
  */
 
 #include "ietf_dtnma_agent.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */
+#include "refda/binding.h"
 #include "refda/eval.h"
 #include "refda/exec.h"
 #include "refda/exec_proc.h"
-#include "refda/binding.h"
 #include "refda/reporting.h"
-#include "cace/amm/promote.h"
+
 #include "cace/amm/numeric.h"
+#include "cace/amm/promote.h"
 #include "cace/ari/text_util.h"
+
 #include <timespec.h>
+
 #include <math.h>
 /*   STOP CUSTOM INCLUDES HERE  */
 

--- a/src/refda/adm/ietf_dtnma_agent.c
+++ b/src/refda/adm/ietf_dtnma_agent.c
@@ -30,11 +30,11 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */
 #include "refda/eval.h"

--- a/src/refda/adm/ietf_dtnma_agent.h
+++ b/src/refda/adm/ietf_dtnma_agent.h
@@ -28,6 +28,7 @@
 #define REFDA_ADM_IETF_DTNMA_AGENT_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */

--- a/src/refda/adm/ietf_dtnma_agent.h
+++ b/src/refda/adm/ietf_dtnma_agent.h
@@ -28,7 +28,7 @@
 #define REFDA_ADM_IETF_DTNMA_AGENT_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE */
 /** Append rows to a table for an IDENT object and any of its derived objects.

--- a/src/refda/adm/ietf_dtnma_agent_acl.c
+++ b/src/refda/adm/ietf_dtnma_agent_acl.c
@@ -24,16 +24,18 @@
  */
 
 #include "ietf_dtnma_agent_acl.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 #include "cace/ari/time_util.h"

--- a/src/refda/adm/ietf_dtnma_agent_acl.c
+++ b/src/refda/adm/ietf_dtnma_agent_acl.c
@@ -29,14 +29,14 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
-#include <cace/ari/time_util.h>
+#include "cace/ari/time_util.h"
 /*   STOP CUSTOM INCLUDES HERE  */
 
 /*   START CUSTOM FUNCTIONS HERE */

--- a/src/refda/adm/ietf_dtnma_agent_acl.h
+++ b/src/refda/adm/ietf_dtnma_agent_acl.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IETF_DTNMA_AGENT_ACL_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_dtnma_agent_acl.h
+++ b/src/refda/adm/ietf_dtnma_agent_acl.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IETF_DTNMA_AGENT_ACL_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_inet_base.c
+++ b/src/refda/adm/ietf_inet_base.c
@@ -24,16 +24,18 @@
  */
 
 #include "ietf_inet_base.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_inet_base.c
+++ b/src/refda/adm/ietf_inet_base.c
@@ -29,11 +29,11 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_inet_base.h
+++ b/src/refda/adm/ietf_inet_base.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IETF_INET_BASE_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/adm/ietf_inet_base.h
+++ b/src/refda/adm/ietf_inet_base.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IETF_INET_BASE_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_network_base.c
+++ b/src/refda/adm/ietf_network_base.c
@@ -24,16 +24,18 @@
  */
 
 #include "ietf_network_base.h"
+
 #include "refda/agent.h"
-#include "refda/register.h"
-#include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
+#include "refda/edd_prod_ctx.h"
 #include "refda/oper_eval_ctx.h"
+#include "refda/register.h"
+
 #include "cace/amm/semtype.h"
 #include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_network_base.c
+++ b/src/refda/adm/ietf_network_base.c
@@ -29,11 +29,11 @@
 #include "refda/edd_prod_ctx.h"
 #include "refda/ctrl_exec_ctx.h"
 #include "refda/oper_eval_ctx.h"
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_network_base.h
+++ b/src/refda/adm/ietf_network_base.h
@@ -27,7 +27,7 @@
 #define REFDA_ADM_IETF_NETWORK_BASE_H_
 
 #include "refda/agent.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */
 /*             TODO              */

--- a/src/refda/adm/ietf_network_base.h
+++ b/src/refda/adm/ietf_network_base.h
@@ -27,6 +27,7 @@
 #define REFDA_ADM_IETF_NETWORK_BASE_H_
 
 #include "refda/agent.h"
+
 #include "cace/util/defs.h"
 
 /*   START CUSTOM INCLUDES HERE  */

--- a/src/refda/agent.c
+++ b/src/refda/agent.c
@@ -16,22 +16,25 @@
  * limitations under the License.
  */
 #include "agent.h"
-#include "ingress.h"
-#include "egress.h"
-#include "exec.h"
-#include "reporting.h"
-#include "amm/typedef.h"
+
 #include "adm/ietf.h"
 #include "adm/ietf_amm_base.h"
 #include "adm/ietf_dtnma_agent.h"
 #include "adm/ietf_dtnma_agent_acl.h"
+#include "amm/typedef.h"
 #include "binding.h"
-#include "cace/ari/text.h"
+#include "egress.h"
+#include "exec.h"
+#include "ingress.h"
+#include "reporting.h"
+
 #include "cace/amm/lookup.h"
-#include "cace/util/threadset.h"
+#include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
+#include "cace/util/threadset.h"
+
 #include <errno.h>
 
 void refda_agent_init(refda_agent_t *agent)

--- a/src/refda/agent.h
+++ b/src/refda/agent.h
@@ -26,11 +26,11 @@
 #include "timeline.h"
 #include "acl.h"
 #include "alarms.h"
-#include <cace/util/daemon_run.h>
-#include <cace/util/threadset.h>
-#include <cace/amm/obj_ns.h>
-#include <cace/amm/obj_store.h>
-#include <cace/amm/msg_if.h>
+#include "cace/util/daemon_run.h"
+#include "cace/util/threadset.h"
+#include "cace/amm/obj_ns.h"
+#include "cace/amm/obj_store.h"
+#include "cace/amm/msg_if.h"
 #include <m-deque.h>
 #include <m-buffer.h>
 #include <pthread.h>

--- a/src/refda/agent.h
+++ b/src/refda/agent.h
@@ -19,20 +19,23 @@
 #ifndef REFDA_AGENT_H_
 #define REFDA_AGENT_H_
 
-#include "instr.h"
-#include "msgdata.h"
-#include "exec_seq.h"
-#include "rpt_agg.h"
-#include "timeline.h"
 #include "acl.h"
 #include "alarms.h"
-#include "cace/util/daemon_run.h"
-#include "cace/util/threadset.h"
+#include "exec_seq.h"
+#include "instr.h"
+#include "msgdata.h"
+#include "rpt_agg.h"
+#include "timeline.h"
+
+#include "cace/amm/msg_if.h"
 #include "cace/amm/obj_ns.h"
 #include "cace/amm/obj_store.h"
-#include "cace/amm/msg_if.h"
-#include <m-deque.h>
+#include "cace/util/daemon_run.h"
+#include "cace/util/threadset.h"
+
 #include <m-buffer.h>
+#include <m-deque.h>
+
 #include <pthread.h>
 
 #ifdef __cplusplus

--- a/src/refda/alarms.c
+++ b/src/refda/alarms.c
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 #include "alarms.h"
+
 #include "agent.h"
 #include "eval.h"
+
 #include "cace/ari/time_util.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 void refda_alarms_history_item_init(refda_alarms_history_item_t *obj)
 {

--- a/src/refda/alarms.h
+++ b/src/refda/alarms.h
@@ -18,11 +18,14 @@
 #ifndef REFDA_ALARMS_H_
 #define REFDA_ALARMS_H_
 
-#include "runctx.h"
 #include "amm/ident.h"
+#include "runctx.h"
+
 #include "cace/ari/base.h"
+
 #include <m-array.h>
 #include <m-dict.h>
+
 #include <pthread.h>
 #include <stdint.h>
 

--- a/src/refda/amm/const.h
+++ b/src/refda/amm/const.h
@@ -18,8 +18,8 @@
 #ifndef REFDA_AMM_CONST_H_
 #define REFDA_AMM_CONST_H_
 
-#include <cace/amm/typing.h>
-#include <cace/ari.h>
+#include "cace/amm/typing.h"
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/amm/ident.c
+++ b/src/refda/amm/ident.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "ident.h"
+
 #include "cace/ari/text.h"
 #include "cace/util/logging.h"
 

--- a/src/refda/amm/ident.h
+++ b/src/refda/amm/ident.h
@@ -21,6 +21,7 @@
 #include "cace/amm/lookup.h"
 #include "cace/amm/obj_store.h"
 #include "cace/amm/user_data.h"
+
 #include <m-deque.h>
 
 #ifdef __cplusplus

--- a/src/refda/amm/oper.h
+++ b/src/refda/amm/oper.h
@@ -18,8 +18,8 @@
 #ifndef REFDA_AMM_OPER_H_
 #define REFDA_AMM_OPER_H_
 
-#include "cace/amm/typing.h"
 #include "cace/amm/named_type.h"
+#include "cace/amm/typing.h"
 #include "cace/ari.h"
 
 #ifdef __cplusplus

--- a/src/refda/amm/oper.h
+++ b/src/refda/amm/oper.h
@@ -18,9 +18,9 @@
 #ifndef REFDA_AMM_OPER_H_
 #define REFDA_AMM_OPER_H_
 
-#include <cace/amm/typing.h>
-#include <cace/amm/named_type.h>
-#include <cace/ari.h>
+#include "cace/amm/typing.h"
+#include "cace/amm/named_type.h"
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/amm/sbr.h
+++ b/src/refda/amm/sbr.h
@@ -18,9 +18,9 @@
 #ifndef REFDA_AMM_SBR_H_
 #define REFDA_AMM_SBR_H_
 
-#include <cace/amm/typing.h>
-#include <cace/ari.h>
-#include <cace/util/defs.h>
+#include "cace/amm/typing.h"
+#include "cace/ari.h"
+#include "cace/util/defs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/amm/tbr.h
+++ b/src/refda/amm/tbr.h
@@ -18,9 +18,9 @@
 #ifndef REFDA_AMM_TBR_H_
 #define REFDA_AMM_TBR_H_
 
-#include <cace/amm/typing.h>
-#include <cace/ari.h>
-#include <cace/util/defs.h>
+#include "cace/amm/typing.h"
+#include "cace/ari.h"
+#include "cace/util/defs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/amm/typedef.c
+++ b/src/refda/amm/typedef.c
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 #include "typedef.h"
-#include "cace/util/logging.h"
+
 #include "cace/ari/text.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 void refda_amm_typedef_desc_init(refda_amm_typedef_desc_t *obj)
 {

--- a/src/refda/amm/var.h
+++ b/src/refda/amm/var.h
@@ -18,8 +18,8 @@
 #ifndef REFDA_AMM_VAR_H_
 #define REFDA_AMM_VAR_H_
 
-#include <cace/amm/typing.h>
-#include <cace/ari.h>
+#include "cace/amm/typing.h"
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/binding.c
+++ b/src/refda/binding.c
@@ -25,13 +25,13 @@
 #include "amm/oper.h"
 #include "amm/sbr.h"
 #include "amm/tbr.h"
-#include <cace/amm/parameters.h>
-#include <cace/amm/lookup.h>
-#include <cace/amm/semtype.h>
-#include <cace/ari.h>
-#include <cace/ari/text.h>
-#include <cace/util/defs.h>
-#include <cace/util/logging.h>
+#include "cace/amm/parameters.h"
+#include "cace/amm/lookup.h"
+#include "cace/amm/semtype.h"
+#include "cace/ari.h"
+#include "cace/ari/text.h"
+#include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 const cace_amm_type_t *refda_binding_type_from_name(const cace_ari_t *name, const cace_amm_obj_store_t *store)
 {

--- a/src/refda/binding.c
+++ b/src/refda/binding.c
@@ -16,17 +16,19 @@
  * limitations under the License.
  */
 #include "binding.h"
-#include "amm/ident.h"
-#include "amm/typedef.h"
+
 #include "amm/const.h"
-#include "amm/var.h"
-#include "amm/edd.h"
 #include "amm/ctrl.h"
+#include "amm/edd.h"
+#include "amm/ident.h"
 #include "amm/oper.h"
 #include "amm/sbr.h"
 #include "amm/tbr.h"
-#include "cace/amm/parameters.h"
+#include "amm/typedef.h"
+#include "amm/var.h"
+
 #include "cace/amm/lookup.h"
+#include "cace/amm/parameters.h"
 #include "cace/amm/semtype.h"
 #include "cace/ari.h"
 #include "cace/ari/text.h"

--- a/src/refda/binding.h
+++ b/src/refda/binding.h
@@ -18,9 +18,9 @@
 #ifndef REFDA_BINDING_H_
 #define REFDA_BINDING_H_
 
-#include <cace/amm/obj_desc.h>
-#include <cace/amm/obj_store.h>
-#include <cace/ari/type.h>
+#include "cace/amm/obj_desc.h"
+#include "cace/amm/obj_store.h"
+#include "cace/ari/type.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/ctrl_exec_ctx.c
+++ b/src/refda/ctrl_exec_ctx.c
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 #include "ctrl_exec_ctx.h"
+
+#include "agent.h"
 #include "exec_seq.h"
 #include "timeline.h"
-#include "agent.h"
-#include "cace/util/logging.h"
+
 #include "cace/ari/text.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 int refda_ctrl_exec_ctx_init(refda_ctrl_exec_ctx_t *obj, refda_exec_item_ptr_t *item_ptr)
 {

--- a/src/refda/ctrl_exec_ctx.h
+++ b/src/refda/ctrl_exec_ctx.h
@@ -19,9 +19,11 @@
 #ifndef REFDA_CTRL_EXEC_CTX_H_
 #define REFDA_CTRL_EXEC_CTX_H_
 
-#include "runctx.h"
 #include "exec_item.h"
+#include "runctx.h"
+
 #include "refda/amm/ctrl.h"
+
 #include "cace/amm/lookup.h"
 #include "cace/ari.h"
 

--- a/src/refda/ctrl_exec_ctx.h
+++ b/src/refda/ctrl_exec_ctx.h
@@ -22,8 +22,8 @@
 #include "runctx.h"
 #include "exec_item.h"
 #include "refda/amm/ctrl.h"
-#include <cace/amm/lookup.h>
-#include <cace/ari.h>
+#include "cace/amm/lookup.h"
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/edd_prod_ctx.c
+++ b/src/refda/edd_prod_ctx.c
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 #include "edd_prod_ctx.h"
-#include "cace/util/logging.h"
+
 #include "cace/ari/text.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 void refda_edd_prod_ctx_init(refda_edd_prod_ctx_t *obj, const refda_amm_edd_desc_t *edd, refda_valprod_ctx_t *prodctx)
 {

--- a/src/refda/edd_prod_ctx.h
+++ b/src/refda/edd_prod_ctx.h
@@ -22,8 +22,8 @@
 #include "agent.h"
 #include "valprod.h"
 #include "refda/amm/edd.h"
-#include <cace/amm/lookup.h>
-#include <cace/ari.h>
+#include "cace/amm/lookup.h"
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/edd_prod_ctx.h
+++ b/src/refda/edd_prod_ctx.h
@@ -21,7 +21,9 @@
 
 #include "agent.h"
 #include "valprod.h"
+
 #include "refda/amm/edd.h"
+
 #include "cace/amm/lookup.h"
 #include "cace/ari.h"
 

--- a/src/refda/egress.c
+++ b/src/refda/egress.c
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 #include "egress.h"
+
 #include "agent.h"
+
 #include "cace/util/logging.h"
 
 void *refda_egress_worker(void *arg)

--- a/src/refda/egress.h
+++ b/src/refda/egress.h
@@ -19,7 +19,7 @@
 #ifndef REFDA_EGRESS_H_
 #define REFDA_EGRESS_H_
 
-#include <cace/util/daemon_run.h>
+#include "cace/util/daemon_run.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/eval.c
+++ b/src/refda/eval.c
@@ -21,11 +21,11 @@
 #include "adm/ietf.h"
 #include "adm/ietf_dtnma_agent.h"
 #include "amm/oper.h"
-#include <cace/ari/text.h>
-#include <cace/amm/lookup.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/ari/text.h"
+#include "cace/amm/lookup.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 /** Expand a reference to a literal value matching SIMPLE or EXPR typedef
  */

--- a/src/refda/eval.c
+++ b/src/refda/eval.c
@@ -16,16 +16,18 @@
  * limitations under the License.
  */
 #include "eval.h"
-#include "oper_eval_ctx.h"
-#include "valprod.h"
+
 #include "adm/ietf.h"
 #include "adm/ietf_dtnma_agent.h"
 #include "amm/oper.h"
-#include "cace/ari/text.h"
+#include "oper_eval_ctx.h"
+#include "valprod.h"
+
 #include "cace/amm/lookup.h"
+#include "cace/ari/text.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 /** Expand a reference to a literal value matching SIMPLE or EXPR typedef
  */

--- a/src/refda/eval.h
+++ b/src/refda/eval.h
@@ -20,8 +20,9 @@
 #define REFDA_EVAL_H_
 
 #include "agent.h"
-#include "runctx.h"
 #include "eval_ctx.h"
+#include "runctx.h"
+
 #include "cace/ari.h"
 
 #ifdef __cplusplus

--- a/src/refda/eval.h
+++ b/src/refda/eval.h
@@ -22,7 +22,7 @@
 #include "agent.h"
 #include "runctx.h"
 #include "eval_ctx.h"
-#include <cace/ari.h>
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/eval_ctx.c
+++ b/src/refda/eval_ctx.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "eval_ctx.h"
+
 #include "cace/util/defs.h"
 
 void refda_eval_ctx_init(refda_eval_ctx_t *obj, refda_runctx_t *parent)

--- a/src/refda/eval_ctx.h
+++ b/src/refda/eval_ctx.h
@@ -20,8 +20,8 @@
 #define REFDA_EVAL_CTX_H_
 
 #include "runctx.h"
-#include <cace/ari.h>
-#include <cace/amm/lookup.h>
+#include "cace/ari.h"
+#include "cace/amm/lookup.h"
 #include <m-variant.h>
 
 #ifdef __cplusplus

--- a/src/refda/eval_ctx.h
+++ b/src/refda/eval_ctx.h
@@ -20,8 +20,10 @@
 #define REFDA_EVAL_CTX_H_
 
 #include "runctx.h"
-#include "cace/ari.h"
+
 #include "cace/amm/lookup.h"
+#include "cace/ari.h"
+
 #include <m-variant.h>
 
 #ifdef __cplusplus

--- a/src/refda/exec.c
+++ b/src/refda/exec.c
@@ -21,12 +21,12 @@
 #include "ctrl_exec_ctx.h"
 #include "valprod.h"
 #include "amm/ctrl.h"
-#include <cace/ari/text.h>
-#include <cace/ari/text_util.h>
-#include <cace/amm/lookup.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/ari/text.h"
+#include "cace/ari/text_util.h"
+#include "cace/amm/lookup.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 #include <timespec.h>
 
 int refda_exec_add_target(refda_runctx_ptr_t *runctxp, const cace_ari_t *target, refda_exec_status_t *status)

--- a/src/refda/exec.c
+++ b/src/refda/exec.c
@@ -16,17 +16,20 @@
  * limitations under the License.
  */
 #include "exec.h"
-#include "exec_proc.h"
-#include "eval.h"
-#include "ctrl_exec_ctx.h"
-#include "valprod.h"
+
 #include "amm/ctrl.h"
+#include "ctrl_exec_ctx.h"
+#include "eval.h"
+#include "exec_proc.h"
+#include "valprod.h"
+
+#include "cace/amm/lookup.h"
 #include "cace/ari/text.h"
 #include "cace/ari/text_util.h"
-#include "cace/amm/lookup.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
+
 #include <timespec.h>
 
 int refda_exec_add_target(refda_runctx_ptr_t *runctxp, const cace_ari_t *target, refda_exec_status_t *status)

--- a/src/refda/exec.h
+++ b/src/refda/exec.h
@@ -19,12 +19,14 @@
 #ifndef REFDA_EXEC_H_
 #define REFDA_EXEC_H_
 
-#include "exec_status.h"
 #include "agent.h"
-#include "runctx.h"
 #include "amm/sbr.h"
 #include "amm/tbr.h"
+#include "exec_status.h"
+#include "runctx.h"
+
 #include "cace/ari.h"
+
 #include <m-atomic.h>
 
 #ifdef __cplusplus

--- a/src/refda/exec.h
+++ b/src/refda/exec.h
@@ -24,7 +24,7 @@
 #include "runctx.h"
 #include "amm/sbr.h"
 #include "amm/tbr.h"
-#include <cace/ari.h>
+#include "cace/ari.h"
 #include <m-atomic.h>
 
 #ifdef __cplusplus

--- a/src/refda/exec_item.c
+++ b/src/refda/exec_item.c
@@ -16,11 +16,13 @@
  * limitations under the License.
  */
 #include "exec_item.h"
-#include "exec_seq.h"
-#include "cace/util/defs.h"
-#include "ctrl_exec_ctx.h"
+
 #include "agent.h"
+#include "ctrl_exec_ctx.h"
+#include "exec_seq.h"
 #include "runctx.h"
+
+#include "cace/util/defs.h"
 
 void refda_exec_item_resume(refda_exec_item_t *obj)
 {

--- a/src/refda/exec_item.c
+++ b/src/refda/exec_item.c
@@ -17,7 +17,7 @@
  */
 #include "exec_item.h"
 #include "exec_seq.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 #include "ctrl_exec_ctx.h"
 #include "agent.h"
 #include "runctx.h"

--- a/src/refda/exec_item.h
+++ b/src/refda/exec_item.h
@@ -19,8 +19,8 @@
 #ifndef REFDA_EXEC_ITEM_H_
 #define REFDA_EXEC_ITEM_H_
 
-#include <cace/amm/lookup.h>
-#include <cace/ari.h>
+#include "cace/amm/lookup.h"
+#include "cace/ari.h"
 #include <m-atomic.h>
 #include <semaphore.h>
 

--- a/src/refda/exec_item.h
+++ b/src/refda/exec_item.h
@@ -21,7 +21,9 @@
 
 #include "cace/amm/lookup.h"
 #include "cace/ari.h"
+
 #include <m-atomic.h>
+
 #include <semaphore.h>
 
 #ifdef __cplusplus

--- a/src/refda/exec_proc.c
+++ b/src/refda/exec_proc.c
@@ -21,12 +21,12 @@
 #include "valprod.h"
 #include "reporting.h"
 #include "amm/ctrl.h"
-#include <cace/ari/text.h>
-#include <cace/ari/text_util.h>
-#include <cace/amm/lookup.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/ari/text.h"
+#include "cace/ari/text_util.h"
+#include "cace/amm/lookup.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 #include <timespec.h>
 
 /** Pop the front execution item after it has finished successfully.

--- a/src/refda/exec_proc.c
+++ b/src/refda/exec_proc.c
@@ -16,17 +16,20 @@
  * limitations under the License.
  */
 #include "exec_proc.h"
-#include "exec.h"
-#include "ctrl_exec_ctx.h"
-#include "valprod.h"
-#include "reporting.h"
+
 #include "amm/ctrl.h"
+#include "ctrl_exec_ctx.h"
+#include "exec.h"
+#include "reporting.h"
+#include "valprod.h"
+
+#include "cace/amm/lookup.h"
 #include "cace/ari/text.h"
 #include "cace/ari/text_util.h"
-#include "cace/amm/lookup.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
+
 #include <timespec.h>
 
 /** Pop the front execution item after it has finished successfully.

--- a/src/refda/exec_proc.h
+++ b/src/refda/exec_proc.h
@@ -23,9 +23,10 @@
 #ifndef REFDA_EXEC_PROC_H_
 #define REFDA_EXEC_PROC_H_
 
-#include "exec_seq.h"
 #include "exec_item.h"
+#include "exec_seq.h"
 #include "runctx.h"
+
 #include <m-deque.h>
 
 #ifdef __cplusplus

--- a/src/refda/exec_seq.c
+++ b/src/refda/exec_seq.c
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 #include "exec_seq.h"
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 void refda_exec_seq_init(refda_exec_seq_t *obj)
 {

--- a/src/refda/exec_seq.c
+++ b/src/refda/exec_seq.c
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 #include "exec_seq.h"
+
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 void refda_exec_seq_init(refda_exec_seq_t *obj)
 {

--- a/src/refda/exec_seq.h
+++ b/src/refda/exec_seq.h
@@ -22,8 +22,10 @@
 #include "exec_item.h"
 #include "exec_status.h"
 #include "runctx.h"
-#include <m-shared-ptr.h>
+
 #include <m-deque.h>
+#include <m-shared-ptr.h>
+
 #include <pthread.h>
 
 #ifdef __cplusplus

--- a/src/refda/exec_status.c
+++ b/src/refda/exec_status.c
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 #include "exec_status.h"
+
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"
+
 #include <stddef.h>
 
 void refda_exec_status_init(refda_exec_status_t *obj)

--- a/src/refda/exec_status.c
+++ b/src/refda/exec_status.c
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 #include "exec_status.h"
-#include <cace/util/defs.h>
-#include <cace/util/logging.h>
+#include "cace/util/defs.h"
+#include "cace/util/logging.h"
 #include <stddef.h>
 
 void refda_exec_status_init(refda_exec_status_t *obj)

--- a/src/refda/exec_status.h
+++ b/src/refda/exec_status.h
@@ -20,6 +20,7 @@
 #define REFDA_EXEC_STATUS_H_
 
 #include <m-atomic.h>
+
 #include <semaphore.h>
 #include <stdbool.h>
 

--- a/src/refda/ingress.c
+++ b/src/refda/ingress.c
@@ -17,9 +17,9 @@
  */
 #include "ingress.h"
 #include "agent.h"
-#include <cace/util/daemon_run.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
+#include "cace/util/daemon_run.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
 
 void *refda_ingress_worker(void *arg)
 {

--- a/src/refda/ingress.c
+++ b/src/refda/ingress.c
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 #include "ingress.h"
+
 #include "agent.h"
+
 #include "cace/util/daemon_run.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"

--- a/src/refda/instr.c
+++ b/src/refda/instr.c
@@ -20,6 +20,7 @@
  * Agent Instrumentation definitions.
  */
 #include "instr.h"
+
 #include "cace/util/defs.h"
 
 void refda_instr_init(refda_instr_t *obj)

--- a/src/refda/instr.c
+++ b/src/refda/instr.c
@@ -20,7 +20,7 @@
  * Agent Instrumentation definitions.
  */
 #include "instr.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 void refda_instr_init(refda_instr_t *obj)
 {

--- a/src/refda/instr.h
+++ b/src/refda/instr.h
@@ -22,10 +22,10 @@
 #ifndef REFDA_INSTR_H_
 #define REFDA_INSTR_H_
 
-#include <cace/config.h>
+#include "cace/config.h"
 #include <m-atomic.h>
 #include <pthread.h>
-#include <cace/ari.h>
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/instr.h
+++ b/src/refda/instr.h
@@ -22,10 +22,12 @@
 #ifndef REFDA_INSTR_H_
 #define REFDA_INSTR_H_
 
-#include "cace/config.h"
-#include <m-atomic.h>
-#include <pthread.h>
 #include "cace/ari.h"
+#include "cace/config.h"
+
+#include <m-atomic.h>
+
+#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/loader.c
+++ b/src/refda/loader.c
@@ -16,14 +16,15 @@
  * limitations under the License.
  */
 #include "loader.h"
+
 #include "adm/ietf.h"
+#include "adm/ietf_alarms.h"
 #include "adm/ietf_amm.h"
 #include "adm/ietf_amm_base.h"
 #include "adm/ietf_amm_semtype.h"
-#include "adm/ietf_network_base.h"
 #include "adm/ietf_dtnma_agent.h"
 #include "adm/ietf_dtnma_agent_acl.h"
-#include "adm/ietf_alarms.h"
+#include "adm/ietf_network_base.h"
 
 int refda_loader_basemods(refda_agent_t *agent)
 {

--- a/src/refda/msgdata.c
+++ b/src/refda/msgdata.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "msgdata.h"
+
 #include "cace/util/defs.h"
 
 void refda_msgdata_init(refda_msgdata_t *obj)

--- a/src/refda/msgdata.c
+++ b/src/refda/msgdata.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 #include "msgdata.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 void refda_msgdata_init(refda_msgdata_t *obj)
 {

--- a/src/refda/msgdata.h
+++ b/src/refda/msgdata.h
@@ -19,7 +19,7 @@
 #ifndef REFDA_MSGDATA_H_
 #define REFDA_MSGDATA_H_
 
-#include <cace/ari.h>
+#include "cace/ari.h"
 #include <m-buffer.h>
 
 #ifdef __cplusplus

--- a/src/refda/msgdata.h
+++ b/src/refda/msgdata.h
@@ -20,6 +20,7 @@
 #define REFDA_MSGDATA_H_
 
 #include "cace/ari.h"
+
 #include <m-buffer.h>
 
 #ifdef __cplusplus

--- a/src/refda/oper_eval_ctx.c
+++ b/src/refda/oper_eval_ctx.c
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 #include "oper_eval_ctx.h"
+
 #include "cace/ari/text.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 void refda_oper_eval_ctx_init(refda_oper_eval_ctx_t *obj)
 {

--- a/src/refda/oper_eval_ctx.c
+++ b/src/refda/oper_eval_ctx.c
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 #include "oper_eval_ctx.h"
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 
 void refda_oper_eval_ctx_init(refda_oper_eval_ctx_t *obj)
 {

--- a/src/refda/oper_eval_ctx.h
+++ b/src/refda/oper_eval_ctx.h
@@ -21,7 +21,9 @@
 
 #include "agent.h"
 #include "eval_ctx.h"
+
 #include "refda/amm/oper.h"
+
 #include "cace/ari.h"
 #include "cace/ari/itemized.h"
 

--- a/src/refda/oper_eval_ctx.h
+++ b/src/refda/oper_eval_ctx.h
@@ -22,8 +22,8 @@
 #include "agent.h"
 #include "eval_ctx.h"
 #include "refda/amm/oper.h"
-#include <cace/ari.h>
-#include <cace/ari/itemized.h>
+#include "cace/ari.h"
+#include "cace/ari/itemized.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/register.c
+++ b/src/refda/register.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "register.h"
+
 #include "cace/util/defs.h"
 
 cace_amm_obj_desc_t *refda_register_ident(cace_amm_obj_ns_t *ns, const cace_amm_idseg_ref_t obj_id,

--- a/src/refda/register.h
+++ b/src/refda/register.h
@@ -18,15 +18,16 @@
 #ifndef REFDA_REGISTER_H_
 #define REFDA_REGISTER_H_
 
-#include "amm/ident.h"
-#include "amm/typedef.h"
 #include "amm/const.h"
-#include "amm/var.h"
-#include "amm/edd.h"
 #include "amm/ctrl.h"
+#include "amm/edd.h"
+#include "amm/ident.h"
 #include "amm/oper.h"
 #include "amm/sbr.h"
 #include "amm/tbr.h"
+#include "amm/typedef.h"
+#include "amm/var.h"
+
 #include "cace/amm/idseg_ref.h"
 #include "cace/amm/obj_ns.h"
 

--- a/src/refda/reporting.c
+++ b/src/refda/reporting.c
@@ -19,10 +19,10 @@
 #include "reporting_ctx.h"
 #include "valprod.h"
 #include "eval.h"
-#include <cace/ari/text.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
-#include <cace/util/logging.h>
+#include "cace/ari/text.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
+#include "cace/util/logging.h"
 
 int refda_reporting_ctrl(refda_runctx_t *runctx, const cace_ari_t *target, cace_ari_t *result)
 {

--- a/src/refda/reporting.c
+++ b/src/refda/reporting.c
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 #include "reporting.h"
+
+#include "eval.h"
 #include "reporting_ctx.h"
 #include "valprod.h"
-#include "eval.h"
+
 #include "cace/ari/text.h"
-#include "cace/util/mutex.h"
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"
+#include "cace/util/mutex.h"
 
 int refda_reporting_ctrl(refda_runctx_t *runctx, const cace_ari_t *target, cace_ari_t *result)
 {

--- a/src/refda/reporting_ctx.c
+++ b/src/refda/reporting_ctx.c
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 #include "reporting_ctx.h"
+
 #include "acl.h"
+
 #include "cace/util/defs.h"
 
 void refda_reporting_ctx_init(refda_reporting_ctx_t *obj, const refda_runctx_t *runctx, const cace_ari_t *mgr_ident)

--- a/src/refda/rpt_agg.h
+++ b/src/refda/rpt_agg.h
@@ -19,7 +19,7 @@
 #ifndef REFDA_RPT_AGG_H_
 #define REFDA_RPT_AGG_H_
 
-#include <cace/ari.h>
+#include "cace/ari.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/refda/runctx.c
+++ b/src/refda/runctx.c
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 #include "runctx.h"
+
 #include "agent.h"
 #include "msgdata.h"
+
 #include "cace/util/defs.h"
 
 void refda_amm_modval_state_init(refda_amm_modval_state_t *obj)

--- a/src/refda/runctx.h
+++ b/src/refda/runctx.h
@@ -19,8 +19,10 @@
 #define REFDA_RUNCTX_H_
 
 #include "acl.h"
-#include "cace/ari/base.h"
+
 #include "cace/amm/lookup.h"
+#include "cace/ari/base.h"
+
 #include <m-shared-ptr.h>
 
 #ifdef __cplusplus

--- a/src/refda/timeline.c
+++ b/src/refda/timeline.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "timeline.h"
+
 #include <timespec.h>
 
 int refda_timeline_event_cmp(const refda_timeline_event_t *lt, const refda_timeline_event_t *rt)

--- a/src/refda/timeline.h
+++ b/src/refda/timeline.h
@@ -19,10 +19,12 @@
 #ifndef REFDA_TIMELINE_H_
 #define REFDA_TIMELINE_H_
 
-#include "exec_item.h"
 #include "ctrl_exec_ctx.h"
+#include "exec_item.h"
 #include "register.h"
+
 #include <m-rbtree.h>
+
 #include <sys/time.h>
 
 #ifdef __cplusplus

--- a/src/refda/valprod.c
+++ b/src/refda/valprod.c
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 #include "valprod.h"
-#include "edd_prod_ctx.h"
+
 #include "amm/const.h"
-#include "amm/var.h"
 #include "amm/edd.h"
-#include "cace/ari/type.h"
+#include "amm/var.h"
+#include "edd_prod_ctx.h"
+
 #include "cace/ari/algo.h"
 #include "cace/ari/text.h"
+#include "cace/ari/type.h"
 #include "cace/util/defs.h"
 #include "cace/util/logging.h"
 

--- a/src/refdm-ion/main.c
+++ b/src/refdm-ion/main.c
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 #include "refdm/mgr.h"
-#include <cace/amp/ion_bp.h>
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/amp/ion_bp.h"
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 #include <signal.h>
 #include <unistd.h>
 

--- a/src/refdm-ion/main.c
+++ b/src/refdm-ion/main.c
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 #include "refdm/mgr.h"
+
 #include "cace/amp/ion_bp.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <signal.h>
 #include <unistd.h>
 

--- a/src/refdm-proxy/main.c
+++ b/src/refdm-proxy/main.c
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 #include "refdm/mgr.h"
-#include <cace/amp/proxy_cli.h>
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/amp/proxy_cli.h"
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 #include <sys/socket.h>
 #include <signal.h>
 #include <unistd.h>

--- a/src/refdm-proxy/main.c
+++ b/src/refdm-proxy/main.c
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 #include "refdm/mgr.h"
+
 #include "cace/amp/proxy_cli.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
-#include <sys/socket.h>
-#include <signal.h>
-#include <unistd.h>
+#include "cace/util/logging.h"
+
 #include <errno.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #if defined(HAVE_LIBSYSTEMD)
 #include <systemd/sd-daemon.h>

--- a/src/refdm-socket/main.c
+++ b/src/refdm-socket/main.c
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 #include "refdm/mgr.h"
+
 #include "cace/amp/socket.h"
-#include "cace/util/logging.h"
 #include "cace/util/defs.h"
+#include "cace/util/logging.h"
+
 #include <signal.h>
 #include <unistd.h>
 

--- a/src/refdm-socket/main.c
+++ b/src/refdm-socket/main.c
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 #include "refdm/mgr.h"
-#include <cace/amp/socket.h>
-#include <cace/util/logging.h>
-#include <cace/util/defs.h>
+#include "cace/amp/socket.h"
+#include "cace/util/logging.h"
+#include "cace/util/defs.h"
 #include <signal.h>
 #include <unistd.h>
 

--- a/src/refdm/agents.c
+++ b/src/refdm/agents.c
@@ -36,10 +36,10 @@
  *****************************************************************************/
 
 #include "agents.h"
-#include <cace/ari/text_util.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/ari/text_util.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 #include <sys/stat.h>
 
 void refdm_agent_init(refdm_agent_t *obj)

--- a/src/refdm/agents.c
+++ b/src/refdm/agents.c
@@ -36,10 +36,12 @@
  *****************************************************************************/
 
 #include "agents.h"
+
 #include "cace/ari/text_util.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
+
 #include <sys/stat.h>
 
 void refdm_agent_init(refdm_agent_t *obj)

--- a/src/refdm/agents.h
+++ b/src/refdm/agents.h
@@ -38,8 +38,8 @@
 #define REFDM_AGENTS_H_
 
 #include "refdm/config.h"
-#include <cace/cace_data.h>
-#include <cace/ari.h>
+#include "cace/cace_data.h"
+#include "cace/ari.h"
 #include <m-string.h>
 #include <pthread.h>
 

--- a/src/refdm/agents.h
+++ b/src/refdm/agents.h
@@ -38,9 +38,12 @@
 #define REFDM_AGENTS_H_
 
 #include "refdm/config.h"
-#include "cace/cace_data.h"
+
 #include "cace/ari.h"
+#include "cace/cace_data.h"
+
 #include <m-string.h>
+
 #include <pthread.h>
 
 #ifdef __cplusplus

--- a/src/refdm/ingress.c
+++ b/src/refdm/ingress.c
@@ -42,8 +42,10 @@
  *****************************************************************************/
 
 #include "ingress.h"
-#include "mgr.h"
+
 #include "agents.h"
+#include "mgr.h"
+
 #include "refdm/config.h"
 #if POSTGRESQL_FOUND
 #include "nm_sql.h"

--- a/src/refdm/ingress.c
+++ b/src/refdm/ingress.c
@@ -48,10 +48,10 @@
 #if POSTGRESQL_FOUND
 #include "nm_sql.h"
 #endif
-#include <cace/ari/text.h>
-#include <cace/util/daemon_run.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
+#include "cace/ari/text.h"
+#include "cace/util/daemon_run.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
 
 /** Handle a received RPTSET value.
  *

--- a/src/refdm/instr.c
+++ b/src/refdm/instr.c
@@ -20,6 +20,7 @@
  * Agent Instrumentation definitions.
  */
 #include "instr.h"
+
 #include "cace/util/defs.h"
 
 void refdm_instr_init(refdm_instr_t *obj)

--- a/src/refdm/instr.c
+++ b/src/refdm/instr.c
@@ -20,7 +20,7 @@
  * Agent Instrumentation definitions.
  */
 #include "instr.h"
-#include <cace/util/defs.h>
+#include "cace/util/defs.h"
 
 void refdm_instr_init(refdm_instr_t *obj)
 {

--- a/src/refdm/mgr.c
+++ b/src/refdm/mgr.c
@@ -40,13 +40,14 @@
  *****************************************************************************/
 
 #include "mgr.h"
+
 #include "ingress.h"
 #if CIVETWEB_FOUND
 #include "nm_rest.h"
 #endif // CIVETWEB_FOUND
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
 
 #if POSTGRESQL_FOUND
 #include "nm_sql.h"

--- a/src/refdm/mgr.c
+++ b/src/refdm/mgr.c
@@ -44,9 +44,9 @@
 #if CIVETWEB_FOUND
 #include "nm_rest.h"
 #endif // CIVETWEB_FOUND
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 
 #if POSTGRESQL_FOUND
 #include "nm_sql.h"

--- a/src/refdm/mgr.h
+++ b/src/refdm/mgr.h
@@ -44,9 +44,9 @@
 #include "agents.h"
 #include "instr.h"
 #include "refdm/config.h"
-#include <cace/amm/msg_if.h>
-#include <cace/util/daemon_run.h>
-#include <cace/util/threadset.h>
+#include "cace/amm/msg_if.h"
+#include "cace/util/daemon_run.h"
+#include "cace/util/threadset.h"
 #include <m-dict.h>
 #include <m-string.h>
 #include <stdio.h>

--- a/src/refdm/mgr.h
+++ b/src/refdm/mgr.h
@@ -43,12 +43,16 @@
 
 #include "agents.h"
 #include "instr.h"
+
 #include "refdm/config.h"
+
 #include "cace/amm/msg_if.h"
 #include "cace/util/daemon_run.h"
 #include "cace/util/threadset.h"
+
 #include <m-dict.h>
 #include <m-string.h>
+
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/src/refdm/nm_rest.c
+++ b/src/refdm/nm_rest.c
@@ -17,12 +17,12 @@
  */
 
 #include "nm_rest.h"
-#include <cace/ari/text_util.h>
-#include <cace/ari/cbor.h>
-#include <cace/ari/text.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
-#include <cace/util/defs.h>
+#include "cace/ari/text_util.h"
+#include "cace/ari/cbor.h"
+#include "cace/ari/text.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
+#include "cace/util/defs.h"
 #include <m-bstring.h>
 // CivetWeb includes
 #include <cjson/cJSON.h>

--- a/src/refdm/nm_rest.c
+++ b/src/refdm/nm_rest.c
@@ -17,16 +17,18 @@
  */
 
 #include "nm_rest.h"
-#include "cace/ari/text_util.h"
+
 #include "cace/ari/cbor.h"
 #include "cace/ari/text.h"
+#include "cace/ari/text_util.h"
+#include "cace/util/defs.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
-#include "cace/util/defs.h"
+
 #include <m-bstring.h>
 // CivetWeb includes
-#include <cjson/cJSON.h>
 #include <civetweb.h>
+#include <cjson/cJSON.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>

--- a/src/refdm/nm_rest.h
+++ b/src/refdm/nm_rest.h
@@ -23,6 +23,7 @@
 #define __NM_REST_H__
 
 #include "mgr.h"
+
 #include "refdm/config.h"
 
 #ifdef __cplusplus

--- a/src/refdm/nm_sql.c
+++ b/src/refdm/nm_sql.c
@@ -20,18 +20,19 @@
  */
 #include "nm_sql.h"
 
-#include "cace/ari/cbor.h"
-#include "cace/amm/typing.h"
 #include "cace/amm/semtype.h"
+#include "cace/amm/typing.h"
+#include "cace/ari/cbor.h"
 #include "cace/ari/text.h"
 #include "cace/ari/text_util.h"
 #include "cace/util/logging.h"
 #include "cace/util/mutex.h"
 
-#include <string.h>
-#include <arpa/inet.h>
 #include <m-bstring.h>
 #include <timespec.h>
+
+#include <arpa/inet.h>
+#include <string.h>
 
 // Constants: Database table names
 const char *TBL_NAME_RPTSET = "ari_rptset";

--- a/src/refdm/nm_sql.c
+++ b/src/refdm/nm_sql.c
@@ -20,13 +20,13 @@
  */
 #include "nm_sql.h"
 
-#include <cace/ari/cbor.h>
-#include <cace/amm/typing.h>
-#include <cace/amm/semtype.h>
-#include <cace/ari/text.h>
-#include <cace/ari/text_util.h>
-#include <cace/util/logging.h>
-#include <cace/util/mutex.h>
+#include "cace/ari/cbor.h"
+#include "cace/amm/typing.h"
+#include "cace/amm/semtype.h"
+#include "cace/ari/text.h"
+#include "cace/ari/text_util.h"
+#include "cace/util/logging.h"
+#include "cace/util/mutex.h"
 
 #include <string.h>
 #include <arpa/inet.h>

--- a/src/refdm/nm_sql.h
+++ b/src/refdm/nm_sql.h
@@ -24,9 +24,9 @@
 #include "agents.h"
 #include "mgr.h"
 #include "refdm/config.h"
-#include <cace/amm/msg_if.h>
-#include <cace/util/defs.h>
-#include <cace/ari.h>
+#include "cace/amm/msg_if.h"
+#include "cace/util/defs.h"
+#include "cace/ari.h"
 /* System Headers */
 #include <stdio.h>
 #include <unistd.h>

--- a/src/refdm/nm_sql.h
+++ b/src/refdm/nm_sql.h
@@ -23,10 +23,12 @@
 
 #include "agents.h"
 #include "mgr.h"
+
 #include "refdm/config.h"
+
 #include "cace/amm/msg_if.h"
-#include "cace/util/defs.h"
 #include "cace/ari.h"
+#include "cace/util/defs.h"
 /* System Headers */
 #include <stdio.h>
 #include <unistd.h>

--- a/test/cace/fuzz_common.h
+++ b/test/cace/fuzz_common.h
@@ -19,6 +19,7 @@
 #define TEST_CACE_FUZZ_COMMON_H_
 
 #include <cace/util/logging.h>
+
 #include <inttypes.h>
 #include <stddef.h>
 

--- a/test/cace/test_amm_lookup.c
+++ b/test/cace/test_amm_lookup.c
@@ -17,9 +17,10 @@
  */
 #include <cace/amm/lookup.h>
 #include <cace/amm/semtype.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_amm_obj_ns.c
+++ b/test/cace/test_amm_obj_ns.c
@@ -16,11 +16,12 @@
  * limitations under the License.
  */
 #include <cace/amm/obj_ns.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
-#include <cace/util/logging.h>
 #include <cace/ari/text.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_amm_parameters.c
+++ b/test/cace/test_amm_parameters.c
@@ -17,9 +17,10 @@
  */
 #include <cace/amm/parameters.h>
 #include <cace/amm/semtype.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_amm_semtype_cnst.c
+++ b/test/cace/test_amm_semtype_cnst.c
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 #include <cace/amm/semtype_cnst.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_amm_typing.c
+++ b/test/cace/test_amm_typing.c
@@ -15,12 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cace/amm/obj_store.h>
 #include <cace/amm/semtype.h>
 #include <cace/amm/typing.h>
-#include <cace/amm/obj_store.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_amp_socket.c
+++ b/test/cace/test_amp_socket.c
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 #include <cace/amp/socket.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/logging.h>
-#include <sys/stat.h>
-#include <errno.h>
-#include <unistd.h>
+
 #include <dirent.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_ari_algo.c
+++ b/test/cace/test_ari_algo.c
@@ -19,11 +19,13 @@
  * Test the algo.h interfaces.
  */
 #include <cace/ari/algo.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
-#include <cace/util/logging.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <m-dict.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_ari_cbor.c
+++ b/test/cace/test_ari_cbor.c
@@ -23,11 +23,12 @@
  *  echo "42" | diag2cbor.rb | xxd -i
  * @endcode
  */
+#include <cace/amm/typing.h>
 #include <cace/ari/cbor.h>
 #include <cace/ari/text.h>
 #include <cace/ari/text_util.h>
-#include <cace/amm/typing.h>
 #include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_ari_roundtrip.c
+++ b/test/cace/test_ari_roundtrip.c
@@ -18,11 +18,12 @@
 /** @file
  * Test the ari_text.h interfaces.
  */
+#include <cace/amm/typing.h>
+#include <cace/ari/cbor.h>
 #include <cace/ari/text.h>
 #include <cace/ari/text_util.h>
-#include <cace/ari/cbor.h>
-#include <cace/amm/typing.h>
 #include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_ari_text.c
+++ b/test/cace/test_ari_text.c
@@ -18,9 +18,10 @@
 /** @file
  * Test the cace_ari_text.h interfaces.
  */
+#include <cace/amm/typing.h>
 #include <cace/ari/text.h>
 #include <cace/ari/text_util.h>
-#include <cace/amm/typing.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/cace/test_ari_text_util.c
+++ b/test/cace/test_ari_text_util.c
@@ -18,10 +18,11 @@
 /** @file
  * Test the ari_text_util.h interfaces.
  */
-#include <cace/ari/text_util.h>
 #include <cace/ari/lit.h>
-#include <unity.h>
+#include <cace/ari/text_util.h>
+
 #include <string.h>
+#include <unity.h>
 
 #define TEST_CASE(...)
 

--- a/test/cace/test_util_range.c
+++ b/test/cace/test_util_range.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include <cace/util/range.h>
+
 #include <stdbool.h>
 #include <unity.h>
 

--- a/test/refda/test_adm_ietf_alarms.c
+++ b/test/refda/test_adm_ietf_alarms.c
@@ -19,26 +19,29 @@
  * Test the external ADM for alarm bookkeeping.
  * This requires some internal API access to manipulate the Agent state.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
 #include "util/runctx.h"
-#include <refda/register.h>
+
+#include <refda/amm/const.h>
+#include <refda/amm/edd.h>
+#include <refda/amm/ident.h>
+#include <refda/amm/var.h>
 #include <refda/binding.h>
-#include <refda/valprod.h>
 #include <refda/exec_proc.h>
+#include <refda/register.h>
+#include <refda/valprod.h>
 #include <refda/adm/ietf.h>
+#include <refda/adm/ietf_alarms.h>
 #include <refda/adm/ietf_amm_base.h>
 #include <refda/adm/ietf_amm_semtype.h>
 #include <refda/adm/ietf_dtnma_agent.h>
 #include <refda/adm/ietf_dtnma_agent_acl.h>
-#include <refda/adm/ietf_alarms.h>
-#include <refda/amm/ident.h>
-#include <refda/amm/const.h>
-#include <refda/amm/var.h>
-#include <refda/amm/edd.h>
+
 #include <cace/amm/semtype.h>
-#include <cace/util/logging.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/refda/test_adm_ietf_dtnma_agent.c
+++ b/test/refda/test_adm_ietf_dtnma_agent.c
@@ -15,23 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
 #include "util/runctx.h"
-#include <refda/register.h>
+
+#include <refda/amm/const.h>
+#include <refda/amm/edd.h>
+#include <refda/amm/var.h>
 #include <refda/binding.h>
+#include <refda/register.h>
 #include <refda/valprod.h>
 #include <refda/adm/ietf.h>
 #include <refda/adm/ietf_amm_base.h>
 #include <refda/adm/ietf_amm_semtype.h>
 #include <refda/adm/ietf_dtnma_agent.h>
 #include <refda/adm/ietf_dtnma_agent_acl.h>
-#include <refda/amm/const.h>
-#include <refda/amm/var.h>
-#include <refda/amm/edd.h>
+
 #include <cace/amm/semtype.h>
-#include <cace/util/logging.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/refda/test_alarms.c
+++ b/test/refda/test_alarms.c
@@ -19,26 +19,29 @@
  * Test the internal API for alarm bookkeeping, separate from the ADM
  * exposing some of these data and behaviors.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
 #include "util/runctx.h"
-#include <refda/register.h>
-#include <refda/binding.h>
-#include <refda/valprod.h>
-#include <refda/exec_proc.h>
-#include <refda/adm/ietf.h>
-#include <refda/adm/ietf_amm_base.h>
-#include <refda/adm/ietf_alarms.h>
-#include <refda/amm/ident.h>
+
 #include <refda/amm/const.h>
-#include <refda/amm/var.h>
 #include <refda/amm/edd.h>
+#include <refda/amm/ident.h>
+#include <refda/amm/var.h>
+#include <refda/binding.h>
+#include <refda/exec_proc.h>
+#include <refda/register.h>
+#include <refda/valprod.h>
+#include <refda/adm/ietf.h>
+#include <refda/adm/ietf_alarms.h>
+#include <refda/adm/ietf_amm_base.h>
+
 #include <cace/amm/semtype.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
 #include <cace/ari/text.h>
-#include <cace/util/logging.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/refda/test_amm_const.c
+++ b/test/refda/test_amm_const.c
@@ -15,17 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
 #include "util/runctx.h"
-#include <refda/amm/const.h>
+
 #include <refda/agent.h>
+#include <refda/amm/const.h>
 #include <refda/valprod.h>
+
 #include <cace/amm/semtype.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
-#include <cace/util/logging.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/refda/test_amm_ctrl.c
+++ b/test/refda/test_amm_ctrl.c
@@ -15,17 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
 #include "util/runctx.h"
+
 #include <refda/ctrl_exec_ctx.h>
 #include <refda/exec_proc.h>
+
 #include <cace/amm/semtype.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
-#include <cace/util/logging.h>
 #include <cace/ari/text.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/refda/test_eval.c
+++ b/test/refda/test_eval.c
@@ -15,23 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
 #include "util/runctx.h"
-#include <refda/eval.h>
-#include <refda/register.h>
-#include <refda/edd_prod_ctx.h>
-#include <refda/oper_eval_ctx.h>
+
 #include <refda/amm/const.h>
 #include <refda/amm/edd.h>
-#include <cace/amm/semtype.h>
-#include <cace/amm/promote.h>
+#include <refda/edd_prod_ctx.h>
+#include <refda/eval.h>
+#include <refda/oper_eval_ctx.h>
+#include <refda/register.h>
+
 #include <cace/amm/numeric.h>
-#include <cace/ari/text_util.h>
+#include <cace/amm/promote.h>
+#include <cace/amm/semtype.h>
 #include <cace/ari/cbor.h>
 #include <cace/ari/text.h>
-#include <cace/util/logging.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/refda/test_exec.c
+++ b/test/refda/test_exec.c
@@ -15,23 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
+
+#include <refda/amm/const.h>
+#include <refda/amm/ctrl.h>
+#include <refda/ctrl_exec_ctx.h>
+#include <refda/edd_prod_ctx.h>
 #include <refda/exec.h>
 #include <refda/exec_proc.h>
 #include <refda/register.h>
-#include <refda/edd_prod_ctx.h>
-#include <refda/ctrl_exec_ctx.h>
-#include <refda/amm/const.h>
-#include <refda/amm/ctrl.h>
 #include <refda/adm/ietf.h>
+
 #include <cace/amm/semtype.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
-#include <cace/util/logging.h>
 #include <cace/ari/text.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <timespec.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/refda/test_reporting.c
+++ b/test/refda/test_reporting.c
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "util/ari.h"
 #include "util/agent.h"
+#include "util/ari.h"
 #include "util/runctx.h"
-#include <refda/reporting.h>
-#include <refda/register.h>
-#include <refda/edd_prod_ctx.h>
+
 #include <refda/amm/const.h>
 #include <refda/amm/edd.h>
+#include <refda/edd_prod_ctx.h>
+#include <refda/register.h>
+#include <refda/reporting.h>
+
 #include <cace/amm/semtype.h>
-#include <cace/ari/text_util.h>
 #include <cace/ari/cbor.h>
-#include <cace/util/logging.h>
 #include <cace/ari/text.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
+
 #include <unity.h>
 
 // Allow this macro

--- a/test/thunk.c
+++ b/test/thunk.c
@@ -17,8 +17,8 @@
  */
 
 /// Provide a name-mapping thunk between OSAL runtime and Unity test function
-#include <osapi-common.h>
 #include <osapi-bsp.h>
+#include <osapi-common.h>
 
 /// The entrypoint name created by unity
 int unity_main(void);

--- a/test/util/agent.c
+++ b/test/util/agent.c
@@ -16,18 +16,21 @@
  * limitations under the License.
  */
 #include "agent.h"
+
 #include <refda/agent.h>
 #include <refda/exec_proc.h>
 #include <refda/adm/ietf.h>
+#include <refda/adm/ietf_alarms.h>
 #include <refda/adm/ietf_amm.h>
 #include <refda/adm/ietf_amm_base.h>
 #include <refda/adm/ietf_amm_semtype.h>
-#include <refda/adm/ietf_network_base.h>
 #include <refda/adm/ietf_dtnma_agent.h>
 #include <refda/adm/ietf_dtnma_agent_acl.h>
-#include <refda/adm/ietf_alarms.h>
+#include <refda/adm/ietf_network_base.h>
+
 #include <cace/ari/time_util.h>
 #include <cace/util/logging.h>
+
 #include <assert.h>
 
 void test_util_agent_crit_adms(refda_agent_t *agent)

--- a/test/util/agent.h
+++ b/test/util/agent.h
@@ -22,9 +22,9 @@
 #include <refda/adm/ietf_amm.h>
 #include <refda/adm/ietf_amm_base.h>
 #include <refda/adm/ietf_amm_semtype.h>
-#include <refda/adm/ietf_network_base.h>
 #include <refda/adm/ietf_dtnma_agent.h>
 #include <refda/adm/ietf_dtnma_agent_acl.h>
+#include <refda/adm/ietf_network_base.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/util/ari.c
+++ b/test/util/ari.c
@@ -17,11 +17,12 @@
  */
 
 #include "ari.h"
-#include <cace/ari/text_util.h>
-#include <cace/ari/text.h>
+
 #include <cace/ari/cbor.h>
-#include <cace/util/logging.h>
+#include <cace/ari/text.h>
+#include <cace/ari/text_util.h>
 #include <cace/util/defs.h>
+#include <cace/util/logging.h>
 
 int test_util_ari_decode(cace_ari_t *ari, const char *inhex)
 {


### PR DESCRIPTION
Be more strict about the style, grouping, and ordering of header includes.

To change the include bracket style under src dir, I used
```bash
find src/ -name '*.h' -o -name '*.c' | xargs sed -i -E 's/include <(cace.+|refda.+|refdm.+)>/include "\1"/g'
```